### PR TITLE
Add native binding for method locateUnityInstalltion

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,5 +21,5 @@
 
 withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token')]) {
 
-    buildGradlePlugin(plaforms:['osx'], coverallsToken: coveralls_token, testEnvironment: [], labels: '')
+    buildGradlePlugin(plaforms:['osx'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity')
 }

--- a/jni/rust/src/lib.rs
+++ b/jni/rust/src/lib.rs
@@ -4,10 +4,12 @@ extern crate uvm_core;
 #[macro_use]
 extern crate error_chain;
 
+use uvm_core::Version;
 use jni::JNIEnv;
-use jni::objects::{JClass, JObject, JValue};
-use jni::sys::{jstring};
+use jni::objects::{JClass, JObject, JValue, JString};
+use jni::sys::{jstring, jobject};
 use std::path::{Path,PathBuf};
+use std::str::FromStr;
 
 mod error {
     use jni;
@@ -25,6 +27,7 @@ mod error {
 
         foreign_links {
             Uvm(uvm_core::error::UvmError);
+            ParseVersionError(uvm_core::unity::ParseVersionError);
             Io(std::io::Error) #[cfg(unix)];
         }
     }
@@ -41,6 +44,13 @@ mod jni_utils {
             .map(|p| Path::new(&String::from(p)).to_path_buf())
             .map_err(|e| e.into())
     }
+
+    pub fn get_file<'a,'b>(env: &'a JNIEnv<'b>, path: &'b Path) -> error::UvmJniResult<JObject<'b>> {
+        let class = env.find_class("java/io/File")?;
+        let path_string = env.new_string(path.to_string_lossy())?;
+        let object = env.new_object(class, "(Ljava/lang/String;)V", &[JValue::Object(path_string.into())])?;
+        Ok(object)
+    }
 }
 
 #[no_mangle]
@@ -53,7 +63,7 @@ pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_uvmVersion(env: JN
 
 #[no_mangle]
 #[allow(non_snake_case)]
-pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_detectProjectVersion<'a>(env: JNIEnv, _class: JClass, path: JObject) -> jstring {
+pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_detectProjectVersion(env: JNIEnv, _class: JClass, path: JObject) -> jstring {
     jni_utils::get_path(&env,path)
         .and_then(|path| {
             uvm_core::dectect_project_version(&path,Some(true)).map_err(|e| e.into())
@@ -62,6 +72,24 @@ pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_detectProjectVersi
             env.new_string(version.to_string()).map_err(|e| e.into())
         })
         .map(|s| s.into_inner() )
+        .unwrap_or_else(|_| {
+            JObject::null().into_inner()
+        })
+}
+
+fn locate_installation(env: &JNIEnv, version: JString) -> error::UvmJniResult<jobject> {
+    let version_string = env.get_string(version)?;
+    let version_string:String = version_string.into();
+    let version = Version::from_str(&version_string)?;
+    let installation = uvm_core::find_installation(&version)?;
+    let object = jni_utils::get_file(&env, &installation.path())?;
+    Ok(object.into_inner())
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_locateUnityInstallation(env: JNIEnv, _class: JClass, version: JString) -> jobject {
+    locate_installation(&env, version)
         .unwrap_or_else(|_| {
             JObject::null().into_inner()
         })

--- a/jni/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/jni/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -51,4 +51,12 @@ public class UnityVersionManager {
      * @return a version string or {@code NULL}
      */
     public static native String detectProjectVersion(File projectPath);
+
+    /**
+     * Returns the path to the installation location for the provided version or {@code Null}.
+     *
+     * @param unityVersion the version string to fetch the installation location for
+     * @return a path to the installation location or {@code Null}
+     */
+    public static native File locateUnityInstallation(String unityVersion);
 }


### PR DESCRIPTION
## Description

This patch adds a new method `File locateUnityInstallation(Stringversion)`. At the moment `uvm` only supports lookup's of installations from their custom installation pattern: `/Applications/Unity-${version}`. Installations located anywhere else on the system won't be picked up. There is the unity hub support feature which will allow to do installation lookup's through unity hub as well as the custom installation destination.

## Changes

![ADD] new native binding `locateUnityInstallation`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

