### PR TITLE
Add hook to plugin net.wooga.unity

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,9 +42,12 @@ github {
 
 repositories {
     mavenCentral()
+    maven { url "https://dl.bintray.com/wooga/maven" }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }
 
 dependencies {
     compile project(':jni')
+    compile "gradle.plugin.net.wooga.gradle:atlas-unity:1.+"
+    testCompile 'net.wooga.test:unity-project-generator-rule:0.2.0'
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtensionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtensionIntegrationSpec.groovy
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.version.manager
+
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import spock.lang.Unroll
+import wooga.gradle.unity.UnityPlugin
+
+class UnityVersionManagerExtensionIntegrationSpec extends IntegrationSpec {
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(UnityVersionManagerPlugin)}
+            ${applyPlugin(UnityPlugin)}
+        """.stripIndent()
+    }
+
+    enum PropertyLocation {
+        none, script, property, env
+    }
+
+    @Unroll
+    def "extension property :#property returns '#value' if #reason with value '#providedValue'"() {
+        given:
+        buildFile << """
+            task(custom) {
+                doLast {
+                    def value = uvm.${property}.get()
+                    println("uvm.${property}: " + value)
+                }
+            }
+        """
+
+        and: "a gradle.properties"
+        def propertiesFile = createFile("gradle.properties")
+
+        switch (location) {
+            case PropertyLocation.script:
+                buildFile << "uvm.${property} = ${value}"
+                break
+            case PropertyLocation.property:
+                propertiesFile << "uvm.${property} = ${value}"
+                break
+            case PropertyLocation.env:
+                environmentVariables.set("UVM_AUTO_SWITCH_UNITY_EDITOR", "${value}")
+                break
+            default:
+                break
+        }
+
+        when:
+        def result = runTasksSuccessfully("custom")
+
+        then:
+        result.standardOutput.contains("uvm.${property}: ${value}")
+
+        where:
+        property                | value | providedValue | reason                           | location
+        "autoSwitchUnityEditor" | true  | true          | "value provided in env"          | PropertyLocation.env
+        "autoSwitchUnityEditor" | true  | 1             | "value provided in env"          | PropertyLocation.env
+        "autoSwitchUnityEditor" | true  | 'TRUE'        | "value provided in env"          | PropertyLocation.env
+        "autoSwitchUnityEditor" | true  | 'y'           | "value provided in env"          | PropertyLocation.env
+        "autoSwitchUnityEditor" | true  | 'yes'         | "value provided in env"          | PropertyLocation.env
+        "autoSwitchUnityEditor" | true  | 'YES'         | "value provided in env"          | PropertyLocation.env
+        "autoSwitchUnityEditor" | true  | true          | "value provided in properties"   | PropertyLocation.property
+        "autoSwitchUnityEditor" | true  | 1             | "value provided in properties"   | PropertyLocation.property
+        "autoSwitchUnityEditor" | true  | 'TRUE'        | "value provided in properties"   | PropertyLocation.property
+        "autoSwitchUnityEditor" | true  | 'y'           | "value provided in properties"   | PropertyLocation.property
+        "autoSwitchUnityEditor" | true  | 'yes'         | "value provided in properties"   | PropertyLocation.property
+        "autoSwitchUnityEditor" | true  | 'YES'         | "value provided in properties"   | PropertyLocation.property
+        "autoSwitchUnityEditor" | true  | true          | "value provided in build script" | PropertyLocation.script
+        "autoSwitchUnityEditor" | false | null          | "no value is set"                | PropertyLocation.none
+    }
+
+
+}

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
@@ -18,6 +18,8 @@
 package wooga.gradle.unity.version.manager
 
 import spock.lang.Unroll
+import wooga.gradle.unity.UnityPlugin
+import wooga.gradle.unity.tasks.Unity
 
 class UnityVersionManagerPluginIntegrationSpec extends IntegrationSpec {
 
@@ -40,4 +42,20 @@ class UnityVersionManagerPluginIntegrationSpec extends IntegrationSpec {
     }
 
 
+    def "creates hooks into atlas-unity when plugin is applied"() {
+        given: "a project with atlas-unity applied"
+        buildFile << """
+            ${applyPlugin(UnityPlugin)}
+
+            task(customUnity, type: ${Unity.name})
+
+        """.stripIndent()
+
+        when:
+        def result = runTasks("customUnity")
+
+        then:
+        result.wasExecuted("customUnity")
+        result.wasExecuted("checkUnityInstallation")
+    }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.version.manager
+
+import net.wooga.test.unity.ProjectGeneratorRule
+import org.junit.Rule
+import spock.lang.Requires
+import spock.lang.Unroll
+import wooga.gradle.unity.UnityPlugin
+import wooga.gradle.unity.tasks.Unity
+
+@Requires({ os.macOs })
+class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
+
+    @Rule
+    ProjectGeneratorRule unityProject = new ProjectGeneratorRule()
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(UnityVersionManagerPlugin)}
+            ${applyPlugin(UnityPlugin)}
+
+            task(customUnity, type: ${Unity.name})
+
+        """.stripIndent()
+        unityProject.projectDir = projectDir
+    }
+
+    static List<String> _installedUnityVersions
+
+    List<String> installedUnityVersions() {
+        if (_installedUnityVersions) {
+            return _installedUnityVersions
+        }
+        def applications = new File("/Applications")
+        _installedUnityVersions = applications.listFiles(new FilenameFilter() {
+            @Override
+            boolean accept(File dir, String name) {
+                return name.startsWith("Unity-")
+            }
+        }).collect {
+            it.name.replace("Unity-", "")
+        }
+    }
+
+    @Unroll
+    def "task :checkUnityInstallation #message and autoSwitchUnityEditor is true"() {
+        given: "A project with a mocked unity version"
+        unityProject.setProjectVersion(editorVersion)
+
+        and: "version switch enabled"
+        buildFile << """
+        uvm.autoSwitchUnityEditor = true
+        """.stripIndent()
+
+        and: "and a custom set unity path no matching project version"
+        buildFile << """
+        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("customUnity")
+
+        then:
+        result.standardOutput.contains(expectedUnityPath.path)
+
+        where:
+        editorVersion | expectedUnityPath
+        "2030.1.2f3"  | new File("/Applications/Unity-${installedUnityVersions().last()}")
+        baseVersion = installedUnityVersions().last()
+        message = "keeps configured path to unity when unity version can't be found"
+    }
+
+    @Unroll
+    def "task :checkUnityInstallation #message if autoSwitchUnityEditor is #autoSwitchEnabled"() {
+        given: "A project with a mocked unity version"
+        unityProject.setProjectVersion(editorVersion)
+
+        and: "version switch enabled"
+        buildFile << """
+        uvm.autoSwitchUnityEditor = ${autoSwitchEnabled}
+        """.stripIndent()
+
+        and: "and a custom set unity path no matching project version"
+        buildFile << """
+        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        """.stripIndent()
+
+        when:
+        def result = runTasksSuccessfully("customUnity")
+
+        then:
+        result.standardOutput.contains(expectedUnityPath.path)
+
+        where:
+        editorVersion                    | expectedUnityPath                                                   | autoSwitchEnabled
+        installedUnityVersions().first() | new File("/Applications/Unity-${installedUnityVersions().first()}") | true
+        installedUnityVersions().first() | new File("/Applications/Unity-${installedUnityVersions().last()}")  | false
+        baseVersion = installedUnityVersions().last()
+        message = autoSwitchEnabled ? "switches path to unity" : "keeps configured path to unity"
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConsts.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConsts.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.version.manager
+
+class UnityVersionManagerConsts {
+
+    /**
+     * Gradle property name to set the default value for {@code autoSwitchUnityEditor}.
+     * @value "uvm.autoSwitchUnityEditor"
+     * @see UnityVersionManagerExtension#getAutoSwitchUnityEditor()
+     */
+    static String AUTO_SWITCH_UNITY_EDITOR_OPTION = "uvm.autoSwitchUnityEditor"
+
+    /**
+     * Environment variable name to set the default value for {@code autoSwitchUnityEditor}.
+     * @value "UVM_AUTO_SWITCH_UNITY_EDITOR"
+     * @see UnityVersionManagerExtension#getAutoSwitchUnityEditor()
+     */
+    static String AUTO_SWITCH_UNITY_EDITOR_PATH_ENV_VAR = "UVM_AUTO_SWITCH_UNITY_EDITOR"
+}

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
@@ -18,6 +18,7 @@
 package wooga.gradle.unity.version.manager
 
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 
 interface UnityVersionManagerExtension {
@@ -38,4 +39,15 @@ interface UnityVersionManagerExtension {
      * A {@code DirectoryProperty} pointing to a unity project.
      */
     DirectoryProperty getUnityProjectDir()
+
+    /**
+     * Enables autoswitch of unity installations.
+     *
+     * Only effects workspaces with {@code net.wooga.unity} plugins applied.
+     * If set to {@code true}, the plugin will switch the Unity path for
+     * {@code net.wooga.unity} to the located unity installation with the matching project version.
+     *
+     * @return {@code true} if autoswitching is enabled
+     */
+    Property<Boolean> getAutoSwitchUnityEditor()
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -17,11 +17,17 @@
 
 package wooga.gradle.unity.version.manager
 
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import org.gradle.api.plugins.AppliedPlugin
+import wooga.gradle.unity.UnityPlugin
+import wooga.gradle.unity.UnityPluginExtension
+import wooga.gradle.unity.tasks.internal.AbstractUnityTask
 import wooga.gradle.unity.version.manager.internal.DefaultUnityVersionManagerExtension
+import wooga.gradle.unity.version.manager.tasks.UvmCheckInstallation
 import wooga.gradle.unity.version.manager.tasks.UvmVersion
 
 class UnityVersionManagerPlugin implements Plugin<Project> {
@@ -43,5 +49,47 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
         project.tasks.create("uvmVersion", UvmVersion) {
             uvmVersion.set(extension.version)
         }
+
+        project.plugins.withType(UnityPlugin, new Action<UnityPlugin>() {
+            @Override
+            void execute(UnityPlugin plugin) {
+                setupUnityHooks(project, extension)
+            }
+        })
+
+    }
+
+    static void setupUnityHooks(Project project, UnityVersionManagerExtension extension) {
+
+        //set the unity project dir to the configured value in UnityPluginExtension
+        UnityPluginExtension unity = project.extensions.getByType(UnityPluginExtension)
+        extension.unityProjectDir.set(project.provider({
+            def projectDir = project.layout.directoryProperty()
+            projectDir.set(project.file(unity.projectPath))
+            projectDir.get()
+        }))
+
+        extension.autoSwitchUnityEditor.set(project.provider({
+            String rawValue = (project.properties[UnityVersionManagerConsts.AUTO_SWITCH_UNITY_EDITOR_OPTION]
+                    ?: System.getenv()[UnityVersionManagerConsts.AUTO_SWITCH_UNITY_EDITOR_PATH_ENV_VAR]) as String
+
+            if(rawValue) {
+                return (rawValue == "1" || rawValue .toLowerCase()== "yes" || rawValue .toLowerCase()== "y" || rawValue .toLowerCase()== "true")
+            }
+
+            false
+        }))
+
+        project.tasks.withType(AbstractUnityTask, new Action<AbstractUnityTask>() {
+            @Override
+            void execute(AbstractUnityTask unityTask) {
+                def checkInstallation = project.tasks.maybeCreate("checkUnityInstallation", UvmCheckInstallation)
+                checkInstallation.projectUnityVersion.set(extension.projectVersion)
+                checkInstallation.autoSwitchUnityEditor.set(extension.autoSwitchUnityEditor)
+                checkInstallation.unityExtension.set(unity)
+                project.tasks[UnityPlugin.ACTIVATE_TASK_NAME].mustRunAfter checkInstallation
+                unityTask.dependsOn checkInstallation
+            }
+        })
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/internal/DefaultUnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/internal/DefaultUnityVersionManagerExtension.groovy
@@ -20,6 +20,7 @@ package wooga.gradle.unity.version.manager.internal
 import net.wooga.uvm.UnityVersionManager
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import wooga.gradle.unity.version.manager.UnityVersionManagerExtension
 
@@ -28,12 +29,18 @@ class DefaultUnityVersionManagerExtension implements UnityVersionManagerExtensio
     final Provider<String> version
     final Provider<String> projectVersion
     final DirectoryProperty unityProjectDir
+    final Property<Boolean> autoSwitchUnityEditor
 
     DefaultUnityVersionManagerExtension(Project project) {
         version = project.provider({ UnityVersionManager.uvmVersion()})
         unityProjectDir = project.layout.directoryProperty()
         unityProjectDir.set(project.layout.projectDirectory)
 
-        projectVersion = project.provider({UnityVersionManager.detectProjectVersion(unityProjectDir.get().asFile)})
+        projectVersion = project.provider({
+            UnityVersionManager.detectProjectVersion(unityProjectDir.get().asFile)
+        })
+
+        autoSwitchUnityEditor = project.objects.property(Boolean)
+        autoSwitchUnityEditor.set(false)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.version.manager.tasks
+
+import net.wooga.uvm.UnityVersionManager
+import org.gradle.api.DefaultTask
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import wooga.gradle.unity.UnityPluginExtension
+
+class UvmCheckInstallation extends DefaultTask {
+
+    @Input
+    @Optional
+    final Property<String> projectUnityVersion
+
+    @Input
+    final Property<UnityPluginExtension> unityExtension
+
+    @Input
+    final Property<Boolean> autoSwitchUnityEditor
+
+    UvmCheckInstallation() {
+        projectUnityVersion = project.objects.property(String)
+        unityExtension = project.objects.property(UnityPluginExtension)
+        autoSwitchUnityEditor = project.objects.property(Boolean)
+    }
+
+    @TaskAction
+    void checkInstalltion() {
+        if (!projectUnityVersion.present) {
+            logger.warn("no unity editor version found")
+            return
+        }
+
+        def version = projectUnityVersion.get()
+        File location = UnityVersionManager.locateUnityInstallation(version)
+
+        if (!location || !location.exists()) {
+            logger.warn("unity version ${version} not installed")
+            return
+        }
+
+        if(!autoSwitchUnityEditor.get()) {
+            logger.info("auto switch editor is turned off")
+            return
+        }
+
+        logger.info("update path to unity installtion ${location}")
+        def extension = unityExtension.get()
+        extension.unityPath = new File(location,"Unity.app/Contents/MacOS/Unity")
+    }
+}


### PR DESCRIPTION
## Description

This patch adds an optional hook for `net.wooga.unity` plugin. If the unity plugin gets applied, all tasks of type `wooga.gradle.unity.tasks.internal.AbstractUnityTask` will be reconfigured to be depended on a new task from the unity version manager plugin `UvmCheckInstallation`.

### UvmCheckInstallation

This task type responsibility is to check the configured project version and check if the system has the specific version of unity installed. If yes and of the unity version manager property `autoSwitchUnityEditor` is set to true, then the unity plugin gets reconfigured to use located
unity version.

This only works for `AbstractUnityTask`'s which don't override the unity location. This needs to be covered in a seperate patch.

## Changes

![ADD] hook in `net.wooga.unity` plugin
![ADD] new task `UvmCheckInstallation`
![ADD] new extension property `autoSwitchUnityEditor`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

