### PR TITLE
Add utility task to list all unity installtions

### DIFF
--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmListInstallatonsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmListInstallatonsIntegrationSpec.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.version.manager
+
+class UvmListInstallatonsIntegrationSpec extends IntegrationSpec {
+
+    List<String> installedUnityVersions() {
+        def applications = new File("/Applications")
+        applications.listFiles(new FilenameFilter() {
+            @Override
+            boolean accept(File dir, String name) {
+                return name.startsWith("Unity-")
+            }
+        }).collect {
+            it.name.replace("Unity-", "")
+        }
+    }
+
+    def setup() {
+        buildFile << """
+            ${applyPlugin(UnityVersionManagerPlugin)}
+        """.stripIndent()
+    }
+
+    def "lists versions"() {
+        given: "some installed versions"
+        def v = installedUnityVersions()
+
+        when:
+        def result = runTasksSuccessfully("listInstallations")
+
+        then:
+        result.standardOutput.contains("installations:")
+        v.each {
+            result.standardOutput.contains("${v} - ")
+        }
+
+    }
+}

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -22,11 +22,11 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.api.plugins.AppliedPlugin
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.tasks.internal.AbstractUnityTask
 import wooga.gradle.unity.version.manager.internal.DefaultUnityVersionManagerExtension
+import wooga.gradle.unity.version.manager.tasks.UvmListInstallations
 import wooga.gradle.unity.version.manager.tasks.UvmCheckInstallation
 import wooga.gradle.unity.version.manager.tasks.UvmVersion
 
@@ -49,6 +49,8 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
         project.tasks.create("uvmVersion", UvmVersion) {
             uvmVersion.set(extension.version)
         }
+
+        project.tasks.create("listInstallations", UvmListInstallations)
 
         project.plugins.withType(UnityPlugin, new Action<UnityPlugin>() {
             @Override

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmListInstallations.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmListInstallations.groovy
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package wooga.gradle.unity.version.manager.tasks
+
+import net.wooga.uvm.UnityVersionManager
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+class UvmListInstallations extends DefaultTask {
+
+    @TaskAction
+    protected void list() {
+        def installations = UnityVersionManager.listInstallations()
+        if(installations.size() > 0) {
+            println("installations:")
+            for (int i = 0; i < installations.length; i++) {
+                def installation = installations[i]
+                println("${installation.version} - ${installation.location.path}")
+
+            }
+        } else {
+            println("No versions installed")
+        }
+    }
+}

--- a/src/test/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginSpec.groovy
@@ -22,6 +22,7 @@ import org.gradle.api.DefaultTask
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.RestoreSystemProperties
 import spock.lang.Unroll
+import wooga.gradle.unity.version.manager.tasks.UvmListInstallations
 
 class UnityVersionManagerPluginSpec extends ProjectSpec {
     public static final String PLUGIN_NAME = 'net.wooga.unity-version-manager'
@@ -40,8 +41,9 @@ class UnityVersionManagerPluginSpec extends ProjectSpec {
         taskType.isInstance(task)
 
         where:
-        taskName     | taskType
-        "uvmVersion" | DefaultTask
+        taskName            | taskType
+        "uvmVersion"        | DefaultTask
+        "listInstallations" | UvmListInstallations
     }
 
     @Rule
@@ -49,7 +51,7 @@ class UnityVersionManagerPluginSpec extends ProjectSpec {
 
     def "doesn't apply anything on windows"() {
         given:
-        System.setProperty("os.name","windows")
+        System.setProperty("os.name", "windows")
 
         assert !project.plugins.hasPlugin(PLUGIN_NAME)
 


### PR DESCRIPTION
## Description

This patch adds a helper task to `net.wooga.unity-version-manager` to list all installed unity versions.

## Changes

![ADD] task `listInstallations` to list unity installations

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

