### PR TITLE
Add native binding to install unity editors custom destination

### DIFF
--- a/jni/rust/Cargo.lock
+++ b/jni/rust/Cargo.lock
@@ -1,9 +1,9 @@
 [[package]]
 name = "aho-corasick"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -54,7 +54,7 @@ name = "base64"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -74,7 +74,7 @@ dependencies = [
 
 [[package]]
 name = "byteorder"
-version = "1.2.6"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -98,9 +98,9 @@ version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "either 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -147,8 +147,8 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -196,8 +196,8 @@ dependencies = [
  "combine 3.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -220,7 +220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -247,7 +247,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "humantime 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -268,7 +268,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -305,11 +305,11 @@ name = "regex"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex-syntax 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -317,7 +317,7 @@ name = "regex-syntax"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -337,7 +337,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "same-file"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -359,8 +359,8 @@ version = "1.0.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.15 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -375,11 +375,11 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "0.15.13"
+version = "0.15.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -389,8 +389,8 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -404,7 +404,7 @@ dependencies = [
 
 [[package]]
 name = "ucd-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -422,17 +422,17 @@ dependencies = [
 
 [[package]]
 name = "utf8-ranges"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "uvm_core"
 version = "0.0.1"
-source = "git+https://github.com/Larusso/unity-version-manager.git?branch=feature/unity-hub-support#e885f248c17f48e30283e9daa60c4c9a71508f6a"
+source = "git+https://github.com/Larusso/unity-version-manager.git?branch=feature/unity-hub-support#9e5cbf6e77b1d6cf89d6a58b7af83949dfdaa67f"
 dependencies = [
  "dirs 1.0.4 (git+https://github.com/Larusso/dirs-rs.git)",
  "itertools 0.7.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -446,6 +446,7 @@ version = "0.0.1"
 dependencies = [
  "error-chain 0.12.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jni 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "uvm_core 0.0.1 (git+https://github.com/Larusso/unity-version-manager.git?branch=feature/unity-hub-support)",
 ]
 
@@ -461,10 +462,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "walkdir"
-version = "2.2.5"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -505,7 +506,7 @@ dependencies = [
 ]
 
 [metadata]
-"checksum aho-corasick 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "68f56c7353e5a9547cbd76ed90f7bb5ffc3ba09d4ea9bd1d8c06c8b1142eeb5a"
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum argon2rs 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3f67b0b6a86dae6e67ff4ca2b6201396074996379fba2b92ff649126f37cb392"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
 "checksum ascii 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ae7d751998c189c1d4468cf0a39bb2eae052a9c58d50ebb3b9591ee3813ad50"
@@ -514,7 +515,7 @@ dependencies = [
 "checksum base64 0.9.3 (registry+https://github.com/rust-lang/crates.io-index)" = "489d6c0ed21b11d038c31b6ceccca973e65d73ba3bd8ecb9a2babf5546164643"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum blake2-rfc 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "5d6d530bdd2d52966a6d03b7a964add7ae1a288d25214066fd4b600f0f796400"
-"checksum byteorder 1.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "90492c5858dd7d2e78691cfb89f90d273a2800fc11d98f60786e5d87e2f83781"
+"checksum byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "94f88df23a25417badc922ab0f5716cc1330e87f71ddd9203b3a3ccd9cedf75d"
 "checksum cc 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "f159dfd43363c4d08055a07703eb7a3406b0dac4d0584d96965a3262db3c9d16"
 "checksum cesu8 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
@@ -534,13 +535,13 @@ dependencies = [
 "checksum jni-sys 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 "checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum log 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "d4fcce5fa49cc693c312001daf1d13411c4a5283796bac1084299ea3e567113f"
-"checksum memchr 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4b3629fe9fdbff6daa6c33b90f7c08355c1aca05a3d01fa8063b822fcf185f3b"
+"checksum log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c84ec4b527950aa83a329754b01dbe3f58361d1c5efacd1f6d68c494d08a17c6"
+"checksum memchr 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0a3eb002f0535929f1199681417029ebea04aadc0c7a4224b46be99c7f5d6a16"
 "checksum nodrop 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)" = "9a2228dca57108069a5262f2ed8bd2e82496d2e074a06d1ccc7ce1687b6ae0a2"
 "checksum plist 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0c7316832d9ac5da02786bdc89a3faf0ca07070212b388766e969078fd593edc"
 "checksum proc-macro2 0.4.20 (registry+https://github.com/rust-lang/crates.io-index)" = "3d7b7eaaa90b4a90a932a9ea6666c95a389e424eff347f0f793979289429feee"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
-"checksum quote 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dd636425967c33af890042c483632d33fa7a18f19ad1d7ea72e8998c6ef8dea5"
+"checksum quote 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "63b5829244f52738cfee93b3a165c1911388675be000c888d2fae620dee8fa5b"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum redox_syscall 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "c214e91d3ecf43e9a4e41e578973adeb14b474f2bee858742d127af75a0112b1"
 "checksum redox_users 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "214a97e49be64fd2c86f568dd0cb2c757d2cc53de95b273b6ad0a1c908482f26"
@@ -549,22 +550,22 @@ dependencies = [
 "checksum rustc-demangle 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "bcfe5b13211b4d78e5c2cadfebd7769197d95c639c35a50057eb4c05de811395"
 "checksum ryu 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "7153dd96dade874ab973e098cb62fcdbb89a03682e46b144fd09550998d4a4a7"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
-"checksum same-file 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "10f7794e2fda7f594866840e95f5c5962e886e228e68b6505885811a94dd728c"
+"checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
 "checksum scoped_threadpool 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 "checksum serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "15c141fc7027dd265a47c090bf864cf62b42c4d228bbcf4e51a0c9e2b0d3f7ef"
 "checksum serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)" = "225de307c6302bec3898c51ca302fc94a7a1697ef0845fcee6448f33c032249c"
 "checksum serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)" = "43344e7ce05d0d8280c5940cabb4964bea626aa58b1ec0e8c73fa2a8512a38ce"
-"checksum syn 0.15.13 (registry+https://github.com/rust-lang/crates.io-index)" = "7b4439ee8325b4e4b57e59309c3724c9a4478eaeb4eb094b6f3fac180a3b2876"
+"checksum syn 0.15.15 (registry+https://github.com/rust-lang/crates.io-index)" = "0a9c2bf1e53c21704a7cce1b2a42768f1ae32a6777108a0d7f1faa4bfe7f7c04"
 "checksum synstructure 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "73687139bf99285483c96ac0add482c3776528beac1d97d444f6e91f203a2015"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-"checksum ucd-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd2be2d6639d0f8fe6cdda291ad456e23629558d466e2789d2c3e9892bda285d"
+"checksum ucd-util 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d0f8bfa9ff0cadcd210129ad9d2c5f145c13e9ced3d3e5d948a6213487d52444"
 "checksum unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-"checksum utf8-ranges 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "fd70f467df6810094968e2fce0ee1bd0e87157aceb026a8c083bcf5e25b9efe4"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum uvm_core 0.0.1 (git+https://github.com/Larusso/unity-version-manager.git?branch=feature/unity-hub-support)" = "<none>"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-"checksum walkdir 2.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "af464bc7be7b785c7ac72e266a6b67c4c9070155606f51655a650a6686204e35"
+"checksum walkdir 2.2.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0ffb549f212c31e19f3667c55a7f515b983a84aef10fd0a4d1f9c125425115f3"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"

--- a/jni/rust/Cargo.toml
+++ b/jni/rust/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 jni = "0.10.2"
 uvm_core = { git = "https://github.com/Larusso/unity-version-manager.git", branch="feature/unity-hub-support"}
 error-chain = "0.12.0"
+log = "0.4.6"
 
 [lib]
 crate-type = ["cdylib"]

--- a/jni/rust/src/install.rs
+++ b/jni/rust/src/install.rs
@@ -1,0 +1,213 @@
+use std::collections::HashSet;
+use std::io;
+use std::io::Write;
+use std::path::{PathBuf,Path};
+use std::process;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex, Condvar};
+use std::thread;
+use uvm_core::brew;
+use uvm_core::install;
+use uvm_core::install::InstallVariant;
+use uvm_core::unity::{Installation,Version,Component};
+use uvm_core::unity::hub::editors::EditorInstallation;
+use uvm_core::unity::hub;
+use uvm_core::unity::hub::editors::Editors;
+
+type EditorInstallLock = Mutex<Option<io::Result<()>>>;
+
+#[derive(PartialEq, Eq, Hash, Debug, Clone)]
+struct InstallObject {
+    version: Version,
+    variant: InstallVariant,
+    destination: Option<PathBuf>
+}
+
+fn set_editor_install_lock(editor_installed_lock:&Arc<(EditorInstallLock,Condvar)>, value:io::Result<()>) {
+    let &(ref lock, ref cvar) = &**editor_installed_lock;
+    let mut is_installed = lock.lock().unwrap();
+    *is_installed = Some(value);
+    cvar.notify_all();
+}
+
+fn install_component(install_object:InstallObject, editor_installed_lock:Arc<(EditorInstallLock,Condvar)>) -> io::Result<()> {
+    let installer = install::download_installer(install_object.variant.clone(), &install_object.version)?;
+    debug!("installer location: {}", &installer.display());
+
+    if install_object.variant != InstallVariant::Editor {
+        debug!("aquire editor install lock for {}", &install_object.variant);
+        let &(ref lock, ref cvar) = &*editor_installed_lock;
+        let mut is_installed = lock.lock().unwrap();
+        // As long as the value inside the `Mutex` is false, we wait.
+        while (*is_installed).is_none() {
+            debug!("waiting for editor to finish installation of {}", &install_object.variant);
+            is_installed = cvar.wait(is_installed).unwrap();
+        }
+
+        if let Some(ref is_installed ) = *is_installed {
+            if let Err(err) = is_installed {
+                debug!("editor installation error. Abort installation of {}", &install_object.variant);
+                return Err(io::Error::new(io::ErrorKind::Other, format!("{} failed because of {}", &install_object.variant, InstallVariant::Editor)));
+            }
+            trace!("editor installation finished. Continue installtion of {}", &install_object.variant);
+        }
+    }
+
+    let destination = install_object.clone().destination.ok_or_else(|| {
+        io::Error::new(io::ErrorKind::Other, "Missing installtion destination")
+    })?;
+
+    debug!("install {} to {}",&install_object.variant, &destination.display());
+    let install_f = match &install_object.variant {
+        InstallVariant::Editor => install::install_editor,
+        _ => install::install_module,
+    };
+
+    install_f(&installer, &destination)
+        .map(|result| {
+            debug!("installation finished {}.", &install_object.variant);
+            if install_object.variant == InstallVariant::Editor {
+                set_editor_install_lock(&editor_installed_lock, Ok(()));
+            }
+            result
+        })
+        .map_err(|error| {
+            if install_object.variant == InstallVariant::Editor {
+                let error = io::Error::new(io::ErrorKind::Other, "failed to install edit");
+                set_editor_install_lock(&editor_installed_lock, Err(error));
+            }
+            error
+        })
+}
+
+pub fn install(version:Version, destination: Option<PathBuf>, variants: Option<HashSet<InstallVariant>>) -> uvm_core::result::Result<Installation> {
+    install::ensure_tap_for_version(&version)?;
+    let mut editor_installation = None;
+    let base_dir = if let Some(ref destination) = destination {
+        if destination.exists() && !destination.is_dir() {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "Requested destination is not a directory.").into())
+        }
+        editor_installation = Some(EditorInstallation::new(version.to_owned(), destination.to_path_buf()));
+        destination.to_path_buf()
+    } else {
+        hub::paths::install_path()
+            .map(|path| path.join(format!("{}", version)))
+            .unwrap_or_else(|| Path::new(&format!("/Applications/Unity-{}", version)).to_path_buf())
+    };
+
+    let installation = Installation::new(base_dir.clone());
+    let mut to_install: HashSet<InstallObject> = HashSet::new();
+    let mut installed: HashSet<InstallObject> = HashSet::new();
+
+    if installation.is_err() {
+        let installation_data = InstallObject {
+            version: version.clone(),
+            variant: InstallVariant::Editor,
+            destination: Some(base_dir.to_path_buf()),
+        };
+        to_install.insert(installation_data);
+
+        if let Some(variants) = variants {
+            for variant in variants {
+                let component: Component = variant.into();
+                let variant_destination = component.installpath();
+                let installation_data = InstallObject {
+                    version: version.clone(),
+                    variant: component.into(),
+                    destination: variant_destination.map(|d| base_dir.join(d)),
+                };
+                to_install.insert(installation_data);
+            }
+        } else {
+            info!("No components requested to install");
+        }
+    } else {
+        let installation = installation.unwrap();
+        info!(
+            "Editor already installed at {}",
+            &installation.path().display()
+        );
+        let base_dir = installation.path();
+        if let Some(variants) = variants {
+            for variant in variants {
+                let component: Component = variant.into();
+                let variant_destination = component.installpath();
+                let installation_data = InstallObject {
+                    version: version.clone(),
+                    variant: component.into(),
+                    destination: variant_destination.map(|d| base_dir.join(d)),
+                };
+                to_install.insert(installation_data);
+            }
+        }
+
+        if !to_install.is_empty() {
+            for component in installation.installed_components() {
+                let variant_destination = component.installpath();
+                let installation_data = InstallObject {
+                    version: version.clone(),
+                    variant: component.into(),
+                    destination: variant_destination.map(|d| base_dir.join(d)),
+                };
+                installed.insert(installation_data);
+            }
+        }
+    }
+
+    let mut diff = to_install.difference(&installed).cloned();
+
+    let mut threads: Vec<thread::JoinHandle<io::Result<()>>> = Vec::new();
+    let editor_installed_lock = Arc::new((Mutex::new(None), Condvar::new()));
+    let mut editor_installing = false;
+    let size = to_install.len();
+    let mut counter = 1;
+
+    for install_object in diff {
+        let editor_installed_lock_c = editor_installed_lock.clone();
+        editor_installing |= install_object.variant == InstallVariant::Editor;
+        counter += 1;
+        threads.push(thread::spawn(move || {
+            install_component(install_object, editor_installed_lock_c)
+        }));
+    }
+
+    if !editor_installing {
+        set_editor_install_lock(&editor_installed_lock, Ok(()));
+    }
+
+    threads
+        .into_iter()
+        .map(thread::JoinHandle::join)
+        .map(|thread_result| match thread_result {
+            Ok(x) => x,
+            Err(_) => Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Install thread failed",
+            )),
+        })
+        .fold(Ok(()), |acc, r| {
+            if let Err(x) = r {
+                if let Err(y) = acc {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!("{}\n{}", y, x),
+                    ));
+                }
+                return Err(io::Error::new(io::ErrorKind::Other, x));
+            }
+            acc
+        })?;
+
+    //write new unity hub editor installation
+    if let Some(installation) = editor_installation {
+        let mut editors = Editors::load()
+            .and_then(|mut editors| {
+                editors.add(installation);
+                editors.flush();
+                Ok(())
+            });
+    }
+
+    let installation = Installation::new(base_dir.clone())?;
+    Ok(installation)
+}

--- a/jni/rust/src/lib.rs
+++ b/jni/rust/src/lib.rs
@@ -3,13 +3,20 @@ extern crate jni;
 extern crate uvm_core;
 #[macro_use]
 extern crate error_chain;
+#[macro_use]
+extern crate log;
+
+
+mod install;
 
 use uvm_core::Version;
 use jni::JNIEnv;
 use jni::objects::{JClass, JObject, JValue, JString};
-use jni::sys::{jstring, jobject, jobjectArray, jsize};
+use jni::sys::{jstring, jobject, jobjectArray, jsize, jboolean, jint};
 use std::path::{Path,PathBuf};
 use std::str::FromStr;
+use std::collections::HashSet;
+use uvm_core::install::InstallVariant;
 
 mod error {
     use jni;
@@ -35,6 +42,7 @@ mod error {
 
 mod jni_utils {
     use super::*;
+    use uvm_core::unity;
 
     /// Converts a `java.io.File` `JObject` into a `PathBuf`
     pub fn get_path(env: &JNIEnv, path: JObject) -> error::UvmJniResult<PathBuf> {
@@ -50,6 +58,14 @@ mod jni_utils {
         let path_string = env.new_string(path.to_string_lossy())?;
         let object = env.new_object(class, "(Ljava/lang/String;)V", &[JValue::Object(path_string.into())])?;
         Ok(object)
+    }
+
+    pub fn get_installation<'a, 'b>(env: &'a JNIEnv<'b>, installation: &'b unity::Installation) -> error::UvmJniResult<JObject<'b>> {
+        let installation_class = env.find_class("net/wooga/uvm/Installation")?;
+        let install_path = jni_utils::get_file(&env, installation.path())?;
+        let install_version = env.new_string(installation.version().to_string())?;
+        let native_installation = env.new_object(installation_class, "(Ljava/io/File;Ljava/lang/String;)V", &[JValue::Object(install_path.into()), JValue::Object(install_version.into())])?;
+        Ok(native_installation)
     }
 }
 
@@ -68,9 +84,7 @@ fn list_installations(env: &JNIEnv) -> error::UvmJniResult<jobjectArray> {
 
     let output = env.new_object_array(installations.len() as jsize,installation_class,JObject::null())?;
     for (i, installation) in installations.iter().enumerate() {
-        let install_path = jni_utils::get_file(&env, installation.path())?;
-        let install_version = env.new_string(installation.version().to_string())?;
-        let native_installation = env.new_object(installation_class, "(Ljava/io/File;Ljava/lang/String;)V", &[JValue::Object(install_path.into()), JValue::Object(install_version.into())])?;
+        let native_installation = jni_utils::get_installation(&env, &installation)?;
         env.set_object_array_element(output, i as jsize, native_installation)?;
     }
 
@@ -115,6 +129,72 @@ fn locate_installation(env: &JNIEnv, version: JString) -> error::UvmJniResult<jo
 #[allow(non_snake_case)]
 pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_locateUnityInstallation(env: JNIEnv, _class: JClass, version: JString) -> jobject {
     locate_installation(&env, version)
+        .unwrap_or_else(|_| {
+            JObject::null().into_inner()
+        })
+}
+
+struct Variant(InstallVariant);
+
+impl Variant {
+    pub fn value(self) -> InstallVariant {
+        self.0
+    }
+}
+
+impl From<jint> for Variant {
+    fn from(component: jint) -> Self {
+        match component {
+            0 => Variant(InstallVariant::Android),
+            1 => Variant(InstallVariant::Ios),
+            2 => Variant(InstallVariant::WebGl),
+            3 => Variant(InstallVariant::Linux),
+            4 => Variant(InstallVariant::Windows),
+            5 => Variant(InstallVariant::WindowsMono),
+            _ => Variant(InstallVariant::Android),
+        }
+    }
+}
+
+fn install_unity_editor(env: &JNIEnv, version: JString, destination: JObject, components:Option<jobjectArray>) -> error::UvmJniResult<jobject> {
+    let version = env.get_string(version)?;
+    let version:String = version.into();
+    let version = Version::from_str(&version)?;
+    let destination = jni_utils::get_path(env,destination)?;
+
+    let variants = if let Some(components) = components {
+        let length = env.get_array_length(components)?;
+        let mut variants: HashSet<InstallVariant> = HashSet::with_capacity(length as usize);
+        for i in 0..length {
+            let item = env.get_object_array_element(components, i)?;
+            let item_value = env.call_method(item, "value", "()I", &[])?;
+            let item_value: jint = item_value.i()?;
+            let variant: Variant = item_value.into();
+            variants.insert(variant.value());
+        }
+        Some(variants)
+    } else {
+        None
+    };
+
+    let installation = install::install(version, Some(destination), variants)?;
+    let native_installation = jni_utils::get_installation(&env,&installation)?;
+    Ok(native_installation.into_inner())
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor__Ljava_lang_String_2Ljava_io_File_2(env: JNIEnv, _class: JClass, version: JString, destination: JObject) -> jobject {
+    install_unity_editor(&env, version, destination, None)
+        .unwrap_or_else(|_| {
+            JObject::null().into_inner()
+        })
+}
+
+#[no_mangle]
+#[allow(non_snake_case)]
+pub extern "system" fn Java_net_wooga_uvm_UnityVersionManager_installUnityEditor__Ljava_lang_String_2Ljava_io_File_2_3Lnet_wooga_uvm_Component_2(env: JNIEnv, _class: JClass, version: JString, destination: JObject, components: jobjectArray) -> jobject {
+    install_unity_editor(&env, version, destination, Some(components))
         .unwrap_or_else(|_| {
             JObject::null().into_inner()
         })

--- a/jni/src/main/java/net/wooga/uvm/Component.java
+++ b/jni/src/main/java/net/wooga/uvm/Component.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.wooga.uvm;
+
+public enum Component {
+    android(0),
+    ios(1),
+    webGl(2),
+    linux(3),
+    windows(4),
+    windowsMono(5);
+
+    Component(int value) {
+        this.value = value;
+    }
+
+    private final int value;
+
+    public int value() {
+        return value;
+    }
+}

--- a/jni/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/jni/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -44,6 +44,11 @@ public class UnityVersionManager {
      */
     public static native String uvmVersion();
 
+    /**
+     * Lists Unity installations.
+     *
+     * @return an array of {@code Installation} or null
+     */
     public static native Installation[] listInstallations();
 
     /**
@@ -61,4 +66,30 @@ public class UnityVersionManager {
      * @return a path to the installation location or {@code Null}
      */
     public static native File locateUnityInstallation(String unityVersion);
+
+    /**
+     * Installs the given version of unity to destination.
+     *
+     * If the unity version is already installed, returns early.
+     *
+     * @param version the version of unity to install
+     * @param destination the location to install unity to
+     * @return a {@code Installation} object or null
+     */
+    public static native Installation installUnityEditor(String version, File destination);
+
+    /**
+     * Installs the given version of unity and additional components to destination.
+     *
+     * If the unity version and all requested components are already installed, returns early.
+     *
+     * @param version the version of unity to install
+     * @param destination the location to install unity to
+     * @param components a list of optional {@code Component}s to install
+     *
+     * @return a {@code Installation} object or null
+     * @see Component
+     * @see Installation
+     */
+    public static native Installation installUnityEditor(String version, File destination, Component[] components);
 }


### PR DESCRIPTION
## Description

This patch adds JNI bindings to call a custom install method on uvm. UVM will download the nessary installers and installs unity to the provided destination. Before install UVM will check if the provided version and all its components are installed.

## Changes

![ADD] new native binding to `installUnityEditor`
![ADD] new native binding to `installUnityEditor` and optional components
![ADD] helper enum `Components`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "IMPROVE"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"