### PR TITLE
Refactor and cleanup extension properties

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
@@ -26,14 +26,16 @@ interface UnityVersionManagerExtension {
     /**
      * Returns the uvm core library version.
      */
-    Provider<String> getVersion()
+    Provider<String> getUvmVersion()
 
     /**
-     * The unity editor version located at {@code getUnityProjectDir()}.
+     * The unity editor version used for this project.
+     *
+     * Sets the unity version used for this project. The default value will be fetched from the unity project settings.
      *
      * @see #getUnityProjectDir()
      */
-    Provider<String> getProjectVersion()
+    Property<String> getUnityVersion()
 
     /**
      * A {@code DirectoryProperty} pointing to a unity project.

--- a/src/main/groovy/wooga/gradle/unity/version/manager/internal/DefaultUnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/internal/DefaultUnityVersionManagerExtension.groovy
@@ -26,21 +26,15 @@ import wooga.gradle.unity.version.manager.UnityVersionManagerExtension
 
 class DefaultUnityVersionManagerExtension implements UnityVersionManagerExtension {
 
-    final Provider<String> version
-    final Provider<String> projectVersion
+    final Provider<String> uvmVersion
+    final Property<String> unityVersion
     final DirectoryProperty unityProjectDir
     final Property<Boolean> autoSwitchUnityEditor
 
     DefaultUnityVersionManagerExtension(Project project) {
-        version = project.provider({ UnityVersionManager.uvmVersion()})
+        uvmVersion = project.provider({ UnityVersionManager.uvmVersion()})
         unityProjectDir = project.layout.directoryProperty()
-        unityProjectDir.set(project.layout.projectDirectory)
-
-        projectVersion = project.provider({
-            UnityVersionManager.detectProjectVersion(unityProjectDir.get().asFile)
-        })
-
+        unityVersion = project.objects.property(String)
         autoSwitchUnityEditor = project.objects.property(Boolean)
-        autoSwitchUnityEditor.set(false)
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -29,7 +29,7 @@ class UvmCheckInstallation extends DefaultTask {
 
     @Input
     @Optional
-    final Property<String> projectUnityVersion
+    final Property<String> unityVersion
 
     @Input
     final Property<UnityPluginExtension> unityExtension
@@ -38,19 +38,19 @@ class UvmCheckInstallation extends DefaultTask {
     final Property<Boolean> autoSwitchUnityEditor
 
     UvmCheckInstallation() {
-        projectUnityVersion = project.objects.property(String)
+        unityVersion = project.objects.property(String)
         unityExtension = project.objects.property(UnityPluginExtension)
         autoSwitchUnityEditor = project.objects.property(Boolean)
     }
 
     @TaskAction
     void checkInstalltion() {
-        if (!projectUnityVersion.present) {
+        if (!unityVersion.present) {
             logger.warn("no unity editor version found")
             return
         }
 
-        def version = projectUnityVersion.get()
+        def version = unityVersion.get()
         File location = UnityVersionManager.locateUnityInstallation(version)
 
         if (!location || !location.exists()) {


### PR DESCRIPTION
## Description

This patch includes some breaking changes for cleanup reasons. As a preparation for installing unity versions at build time it was necessary to get rid of some undesired ambiguities.

The setup of the `UnityVersionManagerExtension` is now done completely done in `UnityVersionManagerPlugin` to make it more clear that the extension object is also just a model.

This change makes it possible to set the desired unity version to use in the `build.gradle` file. This allows the CI system or a developer to switch unity versions easily. The default value is still the editor version configured in the unity project settings.

## Changes

![CHANGE] rename property `version` to `uvmVersion`
![CHANGE] rename property `projectVersion` to `unityVersion`
![CHANGE] `unityVersion` type to property
![IMPROVE] extension configuration

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

