### PR TITLE
Add functionality to install a unity editor version at buildtime

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConsts.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConsts.groovy
@@ -32,4 +32,32 @@ class UnityVersionManagerConsts {
      * @see UnityVersionManagerExtension#getAutoSwitchUnityEditor()
      */
     static String AUTO_SWITCH_UNITY_EDITOR_PATH_ENV_VAR = "UVM_AUTO_SWITCH_UNITY_EDITOR"
+
+    /**
+     * Gradle property name to set the default value for {@code autoInstallUnityEditor}.
+     * @value "uvm.autoInstallUnityEditor"
+     * @see UnityVersionManagerExtension#getAutoInstallUnityEditor()
+     */
+    static String AUTO_INSTALL_UNITY_EDITOR_OPTION = "uvm.autoInstallUnityEditor"
+
+    /**
+     * Environment variable name to set the default value for {@code autoInstallUnityEditor}.
+     * @value "UVM_AUTO_INSTALL_UNITY_EDITOR"
+     * @see UnityVersionManagerExtension#getAutoInstallUnityEditor()
+     */
+    static String AUTO_INSTALL_UNITY_EDITOR_PATH_ENV_VAR = "UVM_AUTO_INSTALL_UNITY_EDITOR"
+
+    /**
+     * Gradle property name to set the default value for {@code unityInstallBaseDir}.
+     * @value "uvm.unityInstallBaseDir"
+     * @see UnityVersionManagerExtension#getUnityInstallBaseDir()
+     */
+    static String UNITY_INSTALL_BASE_DIR_OPTION = "uvm.unityInstallBaseDir"
+
+    /**
+     * Environment variable name to set the default value for {@code unityInstallBaseDir}.
+     * @value "UVM_UNITY_INSTALL_BASE_DIR"
+     * @see UnityVersionManagerExtension#getUnityInstallBaseDir()
+     */
+    static String UNITY_INSTALL_BASE_DIR_PATH_ENV_VAR = "UVM_UNITY_INSTALL_BASE_DIR"
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
@@ -52,4 +52,16 @@ interface UnityVersionManagerExtension {
      * @return {@code true} if autoswitching is enabled
      */
     Property<Boolean> getAutoSwitchUnityEditor()
+
+    /**
+     * Enables autoinstall of unity if version is not installed.
+     *
+     * @return {@code true} if autoinstall is enabled
+     */
+    Property<Boolean> getAutoInstallUnityEditor()
+
+    /**
+     * @return the basedir to install unity versions into.
+     */
+    DirectoryProperty getUnityInstallBaseDir()
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/internal/DefaultUnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/internal/DefaultUnityVersionManagerExtension.groovy
@@ -30,11 +30,15 @@ class DefaultUnityVersionManagerExtension implements UnityVersionManagerExtensio
     final Property<String> unityVersion
     final DirectoryProperty unityProjectDir
     final Property<Boolean> autoSwitchUnityEditor
+    final Property<Boolean> autoInstallUnityEditor
+    final DirectoryProperty unityInstallBaseDir
 
     DefaultUnityVersionManagerExtension(Project project) {
-        uvmVersion = project.provider({ UnityVersionManager.uvmVersion()})
+        uvmVersion = project.provider({ UnityVersionManager.uvmVersion() })
         unityProjectDir = project.layout.directoryProperty()
         unityVersion = project.objects.property(String)
         autoSwitchUnityEditor = project.objects.property(Boolean)
+        autoInstallUnityEditor = project.objects.property(Boolean)
+        unityInstallBaseDir = project.layout.directoryProperty()
     }
 }


### PR DESCRIPTION
## Description

This patch adds functionality and configuration options to install the configured unity editor version at build time. The main logic is located in `UvmCheckInstallation`. The task will only attempt to install the
version of both `autoSwitchUnityEditor` and `autoInstallUnityEditor` is set to true. The install destination can be provided with `unityInstallBaseDir`. The default value points to `build/unity_installations/${version}`. All of these configuration values can be set via gradle properties and environment variables.

* `uvm.autoSwitchUnityEditor` or `UVM_AUTO_SWITCH_UNITY_EDITOR`
* `uvm.autoInstallUnityEditor` or `UVM_AUTO_INSTALL_UNITY_EDITOR`
* `uvm.unityInstallBaseDir` or `UVM_UNITY_INSTALL_BASE_DIR`

## Changes

![ADD] install logic to `UvmCheckInstallation`
![ADD] install configuration settings to `UnityVersionManagerExtension`
![ADD] install configuration settings to `UvmCheckInstallation`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

