### PR TITLE
Refactor method locateUnityInstallation

### DIFF
--- a/jni/src/main/java/net/wooga/uvm/Installation.java
+++ b/jni/src/main/java/net/wooga/uvm/Installation.java
@@ -17,9 +17,23 @@
 
 package net.wooga.uvm;
 
+import cz.adamh.utils.NativeUtils;
+
 import java.io.File;
+import java.io.IOException;
+import java.util.logging.Logger;
 
 public class Installation {
+
+    private final static Logger logger = Logger.getLogger(Installation.class.getName());
+
+    static {
+        try {
+            NativeUtils.loadLibraryFromJar("/native/" + System.mapLibraryName("uvm_jni"));
+        } catch (IOException e) {
+            logger.warning("unable to load native library: " + System.mapLibraryName("uvm_jni"));
+        }
+    }
 
     private File location;
     private String version;
@@ -36,4 +50,16 @@ public class Installation {
     public String getVersion() {
         return version;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj instanceof Installation) {
+            Installation other = (Installation) obj;
+            return other.location.equals(this.location)
+                    && other.version.equals(this.version);
+        }
+        return false;
+    }
+
+    public native Component[] getComponents();
 }

--- a/jni/src/main/java/net/wooga/uvm/UnityVersionManager.java
+++ b/jni/src/main/java/net/wooga/uvm/UnityVersionManager.java
@@ -63,9 +63,9 @@ public class UnityVersionManager {
      * Returns the path to the installation location for the provided version or {@code Null}.
      *
      * @param unityVersion the version string to fetch the installation location for
-     * @return a path to the installation location or {@code Null}
+     * @return a {@code Installation} object or null
      */
-    public static native File locateUnityInstallation(String unityVersion);
+    public static native Installation locateUnityInstallation(String unityVersion);
 
     /**
      * Installs the given version of unity to destination.

--- a/jni/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
+++ b/jni/src/test/groovy/net/wooga/uvm/UnityVersionManagerSpec.groovy
@@ -114,7 +114,7 @@ class UnityVersionManagerSpec extends Specification {
         where:
         version                          | reason                          | expectedResult
         null                             | "version is null"               | null
-        installedUnityVersions().first() | "when version is installed"     | new File("/Applications/Unity-${installedUnityVersions().first()}")
+        installedUnityVersions().first() | "when version is installed"     | new Installation(new File("/Applications/Unity-${installedUnityVersions().first()}"), installedUnityVersions().first())
         "1.1.1f1"                        | "when version is not installed" | null
         "2018.0.1"                       | "when version is invalid"       | null
 
@@ -131,7 +131,7 @@ class UnityVersionManagerSpec extends Specification {
 
         then:
         installations != null
-        def versions = installations.collect {it.version}
+        def versions = installations.collect { it.version }
         v.each { version ->
             versions.contains(version)
         }
@@ -140,10 +140,10 @@ class UnityVersionManagerSpec extends Specification {
     def "installUnityEditor installs unity to location"() {
         given: "a version to install"
         def version = "2017.1.0f1"
-        assert !UnityVersionManager.listInstallations().collect({it.version}).contains(version)
+        assert !UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
 
         and: "a temp install location"
-        def basedir = Files.createTempDirectory(buildDir.toPath(),"installUnityEditor_without_components" ).toFile()
+        def basedir = Files.createTempDirectory(buildDir.toPath(), "installUnityEditor_without_components").toFile()
         def destination = new File(basedir, version)
         assert !destination.exists()
 
@@ -155,7 +155,7 @@ class UnityVersionManagerSpec extends Specification {
         result.location.exists()
         result.location == destination
         result.version == version
-        UnityVersionManager.listInstallations().collect({it.version}).contains(version)
+        UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
 
         cleanup:
         destination.deleteDir()
@@ -164,10 +164,10 @@ class UnityVersionManagerSpec extends Specification {
     def "installUnityEditor installs unity and components to location"() {
         given: "a version to install"
         def version = "2017.1.0f1"
-        assert !UnityVersionManager.listInstallations().collect({it.version}).contains(version)
+        assert !UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
 
         and: "a temp install location"
-        def basedir = Files.createTempDirectory(buildDir.toPath(),"installUnityEditor_with_components" ).toFile()
+        def basedir = Files.createTempDirectory(buildDir.toPath(), "installUnityEditor_with_components").toFile()
         def destination = new File(basedir, version)
         assert !destination.exists()
 
@@ -183,7 +183,7 @@ class UnityVersionManagerSpec extends Specification {
         result.location.exists()
         result.location == destination
         result.version == version
-        UnityVersionManager.listInstallations().collect({it.version}).contains(version)
+        UnityVersionManager.listInstallations().collect({ it.version }).contains(version)
         destination.exists()
         playbackEngines.exists()
         new File(playbackEngines, "iOSSupport").exists()

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.unity.version.manager.tasks
 
+import net.wooga.uvm.Installation
 import net.wooga.uvm.UnityVersionManager
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -60,12 +61,12 @@ class UvmCheckInstallation extends DefaultTask {
         }
 
         def version = unityVersion.get()
-        File location = UnityVersionManager.locateUnityInstallation(version)
+        Installation installation = UnityVersionManager.locateUnityInstallation(version)
 
-        if (!location || !location.exists()) {
+        if (!installation || !installation.location.exists()) {
             logger.warn("unity version ${version} not installed")
             if (autoSwitchUnityEditor.get() && autoInstallUnityEditor.get()) {
-                def installation = UnityVersionManager.installUnityEditor(version, new File(unityInstallBaseDir.get().asFile, version))
+                installation = UnityVersionManager.installUnityEditor(version, new File(unityInstallBaseDir.get().asFile, version))
                 if(!installation) {
                     logger.error("Unable to install requested unity version ${version}")
                     throw new UvmInstallException("Unable to install requested unity version ${version}")
@@ -79,9 +80,9 @@ class UvmCheckInstallation extends DefaultTask {
             return
         }
 
-        logger.info("update path to unity installtion ${location}")
+        logger.info("update path to unity installtion ${installation.location}")
         def extension = unityExtension.get()
-        extension.unityPath = new File(location,"Unity.app/Contents/MacOS/Unity")
+        extension.unityPath = new File(installation.location,"Unity.app/Contents/MacOS/Unity")
     }
 }
 


### PR DESCRIPTION
## Description

This patch changes the API of `locateUnityInstallation`. Instead of returning a `File` object it returns an `Installation` object to mimic other API's like `installUnityEditor` and `listInstallations`.

## Changes

![CHANGE] `locateUnityInstallation`, return `Installation` object

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

