### PR TITLE
Add native method getComponents to Installation class

### DIFF
--- a/jni/rust/Cargo.toml
+++ b/jni/rust/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Manfred Endres <manfred.endres@tslarusso.de>"]
 
 [dependencies]
 jni = "0.10.2"
-uvm_core = { git = "https://github.com/Larusso/unity-version-manager.git", branch="feature/unity-hub-support"}
+uvm_core = { git = "https://github.com/Larusso/unity-version-manager.git", rev="4959648f38b269e7e7064e65344b797d4833be3b"}
 error-chain = "0.12.0"
 log = "0.4.6"
 

--- a/jni/src/main/java/net/wooga/uvm/Component.java
+++ b/jni/src/main/java/net/wooga/uvm/Component.java
@@ -20,10 +20,17 @@ package net.wooga.uvm;
 public enum Component {
     android(0),
     ios(1),
-    webGl(2),
-    linux(3),
-    windows(4),
-    windowsMono(5);
+    tvOs(2),
+    webGl(3),
+    linux(4),
+    windows(5),
+    windowsMono(6),
+    Editor(7),
+    Mono(8),
+    visualStudio(9),
+    monoDevelop(10),
+    standardAssets(11),
+    documentation(12);
 
     Component(int value) {
         this.value = value;

--- a/jni/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
+++ b/jni/src/test/groovy/net/wooga/uvm/InstallationSpec.groovy
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2017 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package net.wooga.uvm
+
+import spock.lang.Shared
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import java.nio.file.Files
+
+class InstallationSpec extends Specification {
+
+    @Shared
+    def buildDir
+
+    def setup() {
+        buildDir = new File('build/unityVersionManagerSpec')
+        buildDir.mkdirs()
+    }
+
+
+    @Unroll("can call :#method on Installation")
+    def "installation interface doesn't crash"() {
+        given: "An Installation object"
+        def installation = new Installation(null, null)
+
+        when:
+        installation.invokeMethod(method, *arguments)
+        then:
+        noExceptionThrown()
+
+        where:
+        method          | arguments
+        "getComponents" | null
+    }
+
+    @Unroll("method :getComponents returns #valueMessage #reason")
+    def "get components returns list of installed components"() {
+        given: "install unity with specific components"
+        def basedir = Files.createTempDirectory(buildDir.toPath(), "installationSpec_getComponents").toFile()
+        basedir.deleteOnExit()
+        def destination = new File(basedir, version)
+        assert !destination.exists()
+        def installation = UnityVersionManager.installUnityEditor(version, destination, components.toArray() as Component[])
+        assert destination.exists()
+
+        expect:
+        installation.components == expectedComponents.toArray() as Component[]
+
+        cleanup:
+        destination.deleteDir()
+
+        where:
+        components                         | expectedComponents                 | reason
+        [Component.android, Component.ios] | [Component.android, Component.ios] | "when components are installed"
+        []                                 | []                                 | "when no components are installed"
+        version = "2017.1.0f1"
+        valueMessage = components.size() > 0 ? "list of installed components" : "empty list"
+    }
+
+}


### PR DESCRIPTION
## Description

This patch adds a new getter method `getComponents` to the `Installation` class. This getter is bound to a native implementation which  will return an Array with all installed components.

## Changes

![ADD] native getter `getComponents` to `Installation`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

