### PR TITLE
Improve unityVersion property resolution

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConsts.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConsts.groovy
@@ -60,4 +60,18 @@ class UnityVersionManagerConsts {
      * @see UnityVersionManagerExtension#getUnityInstallBaseDir()
      */
     static String UNITY_INSTALL_BASE_DIR_PATH_ENV_VAR = "UVM_UNITY_INSTALL_BASE_DIR"
+
+    /**
+     * Gradle property name to set the default value for {@code unityVersion}.
+     * @value "uvm.unityVersion"
+     * @see UnityVersionManagerExtension#getUnityVersion()
+     */
+    static String UNITY_VERSION_OPTION = "uvm.unityVersion"
+
+    /**
+     * Environment variable name to set the default value for {@code unityVersion}.
+     * @value "UVM_UNITY_VERSION"
+     * @see UnityVersionManagerExtension#getUnityVersion()
+     */
+    static String UNITY_VERSION_ENV_VAR = "UVM_UNITY_VERSION"
 }


### PR DESCRIPTION
## Description

As all other properties from `UnityVersionManagerExtension` the property `unityVersion` property should also be configurable through properties and environment variables.

This patch adds a resolution chain for the property `unityVersion`. As a fallback the unity project version is used.

## Changes

![Improve] property resolution for extension property `unityVersion`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

