### PR TITLE
Filter required unity components

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,5 +21,5 @@
 
 withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token')]) {
 
-    buildGradlePlugin(plaforms:['osx'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity')
+    buildGradlePlugin(plaforms:['osx'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity&&fast')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -50,4 +50,5 @@ dependencies {
     compile "net.wooga:unity-version-manager-jni:0.1.0"
     compile "gradle.plugin.net.wooga.gradle:atlas-unity:1.+"
     testCompile 'net.wooga.test:unity-project-generator-rule:0.2.0'
+    testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
@@ -17,7 +17,13 @@
 
 package wooga.gradle.unity.version.manager
 
-class IntegrationSpec extends nebula.test.IntegrationSpec{
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+
+class IntegrationSpec extends nebula.test.IntegrationSpec {
+
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables()
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")
@@ -25,5 +31,12 @@ class IntegrationSpec extends nebula.test.IntegrationSpec{
             this.gradleVersion = gradleVersion
             fork = true
         }
+
+        environmentVariables.clear(
+                UnityVersionManagerConsts.UNITY_VERSION_ENV_VAR,
+                UnityVersionManagerConsts.UNITY_INSTALL_BASE_DIR_PATH_ENV_VAR,
+                UnityVersionManagerConsts.AUTO_INSTALL_UNITY_EDITOR_PATH_ENV_VAR,
+                UnityVersionManagerConsts.AUTO_SWITCH_UNITY_EDITOR_PATH_ENV_VAR
+        )
     }
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtension.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.unity.version.manager
 
+import net.wooga.uvm.Component
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
@@ -64,4 +65,17 @@ interface UnityVersionManagerExtension {
      * @return the basedir to install unity versions into.
      */
     DirectoryProperty getUnityInstallBaseDir()
+
+    /**
+     * A {@code Provider} object which resolves the required build components needed for the current build.
+     *
+     * This provider collects all tasks of type {@code AbstractUnityProjectTask} and filters tasks that
+     * are included in the {@code TaskExecutionGraph}. If the {@code TaskExecutionGraph} is not ready by the time
+     * this provider is resolved, the filter won't be applied and the {@code Set} of components configured in the
+     * whole build will be returned.
+     *
+     * @param project the gradle project
+     * @return A provider object which resolves the required build components needed for the current build.
+     */
+    Provider<Set<Component>> getBuildRequiredUnityComponentsProvider()
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -28,7 +28,6 @@ import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.UnityPluginExtension
 import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.tasks.internal.AbstractUnityProjectTask
-import wooga.gradle.unity.tasks.internal.AbstractUnityTask
 import wooga.gradle.unity.version.manager.internal.DefaultUnityVersionManagerExtension
 import wooga.gradle.unity.version.manager.tasks.UvmCheckInstallation
 import wooga.gradle.unity.version.manager.tasks.UvmListInstallations
@@ -151,7 +150,6 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
     }
 
     static void setupUnityHooks(Project project, UnityVersionManagerExtension extension) {
-
         //set the unity project dir to the configured value in UnityPluginExtension
         UnityPluginExtension unity = project.extensions.getByType(UnityPluginExtension)
         extension.unityProjectDir.set(project.provider({
@@ -165,10 +163,7 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
             void execute(AbstractUnityProjectTask unityTask) {
                 def checkInstallation = project.tasks.maybeCreate("checkUnityInstallation", UvmCheckInstallation)
                 checkInstallation.unityExtension.set(unity)
-                checkInstallation.buildRequiredUnityComponents.set(project.provider {
-                    def tasks = project.tasks.withType(AbstractUnityProjectTask)
-                    tasks.collect { buildTargetToComponent(it.buildTarget) }.findAll {it != null}
-                })
+                checkInstallation.buildRequiredUnityComponents.set(extension.buildRequiredUnityComponentsProvider)
                 project.tasks[UnityPlugin.ACTIVATE_TASK_NAME].mustRunAfter checkInstallation
                 unityTask.dependsOn checkInstallation
             }


### PR DESCRIPTION
## Description

At the moment the default provider which returns the required unity components needed for the build take into account all configured tasks and not the one actually scheduled to be executed.

This patch adds another filter and removes all `AbstractUnityProjectTask` which are not included in the `TaskExecutionGraph` at resolve time. The filter will return true for all tasks, if the provider gets resolved during build configuration time or any time before the `TaskExecutionGraph` is ready.

The default implementation for the provider is moved to `UnityVersionManagerExtension` as property `buildRequiredUnityComponentsProvider`. This makes it easier to access and reuse this provider for future use.

## Changes

![ADD] task graph filter for required unity components provider
![CHANGE] move required components provider implementation to `UnityVersionManagerExtension`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

