### PR TITLE
Add additional commandline options to UvmListInstallations

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -38,6 +38,10 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
     static Logger logger = Logging.getLogger(UnityVersionManagerPlugin)
 
     static String EXTENSION_NAME = "uvm"
+    static String GROUP = "unity version manager"
+    static String LIST_INSTALLATIONS_TASK_NAME = "listInstallations"
+    static String UVM_VERSION_TASK_NAME = "uvmVersion"
+    static String CHECK_UNITY_INSTALLATION_TASK_NAME = "checkUnityInstallation"
 
     @Override
     void apply(Project project) {
@@ -49,11 +53,16 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
 
         def extension = create_and_configure_extension(project)
 
-        project.tasks.create("uvmVersion", UvmVersion) {
+        project.tasks.create(UVM_VERSION_TASK_NAME, UvmVersion) {
+            group = GROUP
+            description = "prints the version of the unity version manager"
             uvmVersion.set(extension.uvmVersion)
         }
 
-        project.tasks.create("listInstallations", UvmListInstallations)
+        project.tasks.create(LIST_INSTALLATIONS_TASK_NAME, UvmListInstallations) {
+            group = GROUP
+            description = "lists all installed unity versions"
+        }
 
         project.plugins.withType(UnityPlugin, new Action<UnityPlugin>() {
             @Override
@@ -161,7 +170,7 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
         project.tasks.withType(AbstractUnityProjectTask, new Action<AbstractUnityProjectTask>() {
             @Override
             void execute(AbstractUnityProjectTask unityTask) {
-                def checkInstallation = project.tasks.maybeCreate("checkUnityInstallation", UvmCheckInstallation)
+                def checkInstallation = project.tasks.maybeCreate(CHECK_UNITY_INSTALLATION_TASK_NAME, UvmCheckInstallation)
                 checkInstallation.unityExtension.set(unity)
                 checkInstallation.buildRequiredUnityComponents.set(extension.buildRequiredUnityComponentsProvider)
                 project.tasks[UnityPlugin.ACTIVATE_TASK_NAME].mustRunAfter checkInstallation

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -27,7 +27,6 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.options.Option
 import wooga.gradle.unity.UnityPluginExtension
 
 class UvmCheckInstallation extends DefaultTask {

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmListInstallations.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmListInstallations.groovy
@@ -17,24 +17,73 @@
 
 package wooga.gradle.unity.version.manager.tasks
 
+import groovy.io.GroovyPrintStream
 import net.wooga.uvm.UnityVersionManager
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Provider
+import org.gradle.api.tasks.Console
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.options.Option
 
+/**
+ * A utility task to list all installed Unity installations.
+ */
 class UvmListInstallations extends DefaultTask {
+
+    private Boolean printPath
+
+    @Option(option = "print-path", description = "Print the path to the installation")
+    void setPrintPath(Boolean printPath) {
+        this.printPath = printPath
+    }
+
+    @Console
+    Boolean getPrintPath() {
+        this.printPath
+    }
+
+    @Option(option = "output-path", description = "The output path. [default: stdout]")
+    void setOutputFilePath(String path) {
+        outputFile.set(new File(path))
+    }
+
+    @Optional
+    @OutputFile
+    final RegularFileProperty outputFile
+
+    @Internal
+    final Provider<PrintStream> outputPrintStream
+
+    UvmListInstallations() {
+        super()
+        this.outputs.upToDateWhen({ false })
+        this.outputFile = project.layout.fileProperty()
+        this.outputPrintStream = project.provider({
+            this.outputFile.map({
+                new GroovyPrintStream(it.asFile) as PrintStream
+            }).getOrElse(System.out)
+        })
+    }
 
     @TaskAction
     protected void list() {
-        def installations = UnityVersionManager.listInstallations()
-        if(installations.size() > 0) {
-            println("installations:")
-            for (int i = 0; i < installations.length; i++) {
-                def installation = installations[i]
-                println("${installation.version} - ${installation.location.path}")
-
-            }
+        def installations = UnityVersionManager.listInstallations().toList()
+        def out = outputPrintStream.get()
+        if (installations.isEmpty()) {
+            out.println("No versions installed")
         } else {
-            println("No versions installed")
+            out.println("installations:")
+            installations.each {
+                if (getPrintPath()) {
+                    out.println("${it.version} - ${it.location.path}")
+                } else {
+                    out.println("${it.version}")
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Description

This patch adds additional options to the list `listInstallations` task. It is possible to pass commandline arguments to the task the change some input options. This task was never intended to be used in the build lifecycle. You can see a help list of the task by executing:
`gradle help --task listInstallations`

This outputs:

```
Detailed task information for listInstallations

Path
     :listInstallations

Type
     UvmListInstallations (wooga.gradle.unity.version.manager.tasks.UvmListInstallations)

Options
     --output-path     The output path. [default: stdout]

     --print-path     Print the path to the installation

Description
     lists all installed unity versions

Group
     unity version manager
```

## Changes

![IMPROVE] task `listInstallations` by adding commandline options
![IMPROVE] plugin by adding groups and descriptions for tasks

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

