### PR TITLE
Enable windows support for plugin

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,5 +21,5 @@
 
 withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token')]) {
 
-    buildGradlePlugin(plaforms:['osx'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity&&fast')
+    buildGradlePlugin(plaforms:['osx', 'windows'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity&&fast')
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-    compile "net.wooga:unity-version-manager-jni:0.2.0"
+    compile "net.wooga:unity-version-manager-jni:0.2.2"
     compile "gradle.plugin.net.wooga.gradle:atlas-unity:1.+"
     testCompile 'net.wooga.test:unity-project-generator-rule:0.2.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
@@ -21,6 +21,8 @@ import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
 
+import static groovy.json.StringEscapeUtils.escapeJava
+
 class IntegrationSpec extends nebula.test.IntegrationSpec {
 
     @Rule
@@ -42,5 +44,13 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
                 UnityVersionManagerConsts.AUTO_INSTALL_UNITY_EDITOR_PATH_ENV_VAR,
                 UnityVersionManagerConsts.AUTO_SWITCH_UNITY_EDITOR_PATH_ENV_VAR
         )
+    }
+
+    def escapedPath(String path) {
+        String osName = System.getProperty("os.name").toLowerCase()
+        if (osName.contains("windows")) {
+            return escapeJava(path)
+        }
+        path
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
@@ -46,11 +46,76 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
         )
     }
 
-    def escapedPath(String path) {
+    static String escapedPath(String path) {
         String osName = System.getProperty("os.name").toLowerCase()
         if (osName.contains("windows")) {
             return escapeJava(path)
         }
+        path
+    }
+
+    static List<String> _installedUnityVersions
+
+    List<String> installedUnityVersions() {
+        if (_installedUnityVersions) {
+            return _installedUnityVersions
+        }
+
+        def applications = baseUnityPath()
+        _installedUnityVersions = applications.listFiles(new FilenameFilter() {
+            @Override
+            boolean accept(File dir, String name) {
+                return name.startsWith("Unity-")
+            }
+        }).collect {
+            it.name.replace("Unity-", "")
+        }
+    }
+
+    File baseUnityPath() {
+        if (isWindows()) {
+            new File("C:\\Program Files")
+        } else if (isMac()) {
+            new File("/Applications")
+        }
+    }
+
+    File unityExecutablePath() {
+        if (isWindows()) {
+            new File("Editor\\Unity.exe")
+        } else if (isMac()) {
+            new File("Unity.app/Contents/MacOS/Unity")
+        }
+    }
+
+    File unityVersion(String version) {
+        def base = new File(baseUnityPath(), "Unity-${version}")
+        new File(base, unityExecutablePath().path)
+    }
+
+    String pathToUnityVersion(String version) {
+        escapedPath(unityVersion(version).absolutePath)
+    }
+
+    static String OS = System.getProperty("os.name").toLowerCase()
+
+    static boolean isWindows() {
+        return (OS.indexOf("win") >= 0)
+    }
+
+    static boolean isMac() {
+        return (OS.indexOf("mac") >= 0)
+    }
+
+    static String testPath(String path) {
+        if (isWindows()) {
+            if (path.startsWith("/")) {
+                path =  "C:" + path
+            }
+
+            path = path.replace('/', '\\')
+        }
+
         path
     }
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtensionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerExtensionIntegrationSpec.groovy
@@ -49,11 +49,11 @@ class UnityVersionManagerExtensionIntegrationSpec extends IntegrationSpec {
         String reason() {
             switch (this) {
                 case script:
-                    return "value is provided in build script"
+                    return "value is provided in script"
                 case property:
-                    return "value is provided in properties"
+                    return "value is provided in props"
                 case env:
-                    return "value is provided in environment"
+                    return "value is set in env"
                 default:
                     return "no value was configured"
             }
@@ -64,7 +64,7 @@ class UnityVersionManagerExtensionIntegrationSpec extends IntegrationSpec {
         "UVM_${property.replaceAll(/([A-Z])/, "_\$1").toUpperCase()}"
     }
 
-    @Unroll
+    @Unroll(":#property returns '#testValue' if #reason")
     def "extension property :#property returns '#testValue' if #reason"() {
         given:
         buildFile << """
@@ -79,12 +79,14 @@ class UnityVersionManagerExtensionIntegrationSpec extends IntegrationSpec {
         and: "a gradle.properties"
         def propertiesFile = createFile("gradle.properties")
 
+        def escapedValue = (value instanceof String) ? escapedPath(value) : value
+
         switch (location) {
             case PropertyLocation.script:
-                buildFile << "uvm.${property} = ${value}"
+                buildFile << "uvm.${property} = ${escapedValue}"
                 break
             case PropertyLocation.property:
-                propertiesFile << "uvm.${property} = ${value}"
+                propertiesFile << "uvm.${property} = ${escapedValue}"
                 break
             case PropertyLocation.env:
                 environmentVariables.set(envNameFromProperty(property), "${value}")
@@ -98,7 +100,7 @@ class UnityVersionManagerExtensionIntegrationSpec extends IntegrationSpec {
 
         and: "the test value with replace placeholders"
         if (testValue instanceof String) {
-            testValue = testValue.replaceAll("#projectDir#", projectDir.path)
+            testValue = testValue.replaceAll("#projectDir#", escapedPath(projectDir.path))
         }
 
         when: ""
@@ -108,49 +110,47 @@ class UnityVersionManagerExtensionIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains("uvm.${property}: ${testValue}")
 
         where:
-        property                 | value                  | expectedValue                            | providedValue | location
-        "autoSwitchUnityEditor"  | true                   | _                                        | true          | PropertyLocation.env
-        "autoSwitchUnityEditor"  | true                   | _                                        | 1             | PropertyLocation.env
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'TRUE'        | PropertyLocation.env
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'y'           | PropertyLocation.env
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'yes'         | PropertyLocation.env
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'YES'         | PropertyLocation.env
-        "autoSwitchUnityEditor"  | true                   | _                                        | true          | PropertyLocation.property
-        "autoSwitchUnityEditor"  | true                   | _                                        | 1             | PropertyLocation.property
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'TRUE'        | PropertyLocation.property
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'y'           | PropertyLocation.property
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'yes'         | PropertyLocation.property
-        "autoSwitchUnityEditor"  | true                   | _                                        | 'YES'         | PropertyLocation.property
-        "autoSwitchUnityEditor"  | true                   | _                                        | true          | PropertyLocation.script
-        "autoSwitchUnityEditor"  | false                  | _                                        | null          | PropertyLocation.none
+        property                 | value                                 | expectedValue                                      | providedValue | location
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | true          | PropertyLocation.env
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 1             | PropertyLocation.env
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'TRUE'        | PropertyLocation.env
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'y'           | PropertyLocation.env
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'yes'         | PropertyLocation.env
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'YES'         | PropertyLocation.env
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | true          | PropertyLocation.property
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 1             | PropertyLocation.property
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'TRUE'        | PropertyLocation.property
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'y'           | PropertyLocation.property
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'yes'         | PropertyLocation.property
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | 'YES'         | PropertyLocation.property
+        "autoSwitchUnityEditor"  | true                                  | _                                                  | true          | PropertyLocation.script
+        "autoSwitchUnityEditor"  | false                                 | _                                                  | null          | PropertyLocation.none
 
-        "autoInstallUnityEditor" | true                   | _                                        | true          | PropertyLocation.env
-        "autoInstallUnityEditor" | true                   | _                                        | 1             | PropertyLocation.env
-        "autoInstallUnityEditor" | true                   | _                                        | 'TRUE'        | PropertyLocation.env
-        "autoInstallUnityEditor" | true                   | _                                        | 'y'           | PropertyLocation.env
-        "autoInstallUnityEditor" | true                   | _                                        | 'yes'         | PropertyLocation.env
-        "autoInstallUnityEditor" | true                   | _                                        | 'YES'         | PropertyLocation.env
-        "autoInstallUnityEditor" | true                   | _                                        | true          | PropertyLocation.property
-        "autoInstallUnityEditor" | true                   | _                                        | 1             | PropertyLocation.property
-        "autoInstallUnityEditor" | true                   | _                                        | 'TRUE'        | PropertyLocation.property
-        "autoInstallUnityEditor" | true                   | _                                        | 'y'           | PropertyLocation.property
-        "autoInstallUnityEditor" | true                   | _                                        | 'yes'         | PropertyLocation.property
-        "autoInstallUnityEditor" | true                   | _                                        | 'YES'         | PropertyLocation.property
-        "autoInstallUnityEditor" | true                   | _                                        | true          | PropertyLocation.script
-        "autoInstallUnityEditor" | false                  | _                                        | null          | PropertyLocation.none
-
-        "unityInstallBaseDir"    | "/custom/path"         | _                                        | "path string" | PropertyLocation.env
-        "unityInstallBaseDir"    | "/custom/path"         | _                                        | "path string" | PropertyLocation.property
-        "unityInstallBaseDir"    | "file('/custom/path')" | "/custom/path"                           | "path string" | PropertyLocation.script
-        "unityInstallBaseDir"    | null                   | "#projectDir#/build/unity_installations" | "null"        | PropertyLocation.none
-
-        "unityVersion"           | "2017.2.4f5"           | _                                        | "2017.2.4f5"  | PropertyLocation.env
-        "unityVersion"           | "2018.3.1b4"           | _                                        | "2018.3.1b4"  | PropertyLocation.property
-        "unityVersion"           | "'2019.2.1f1'"         | "2019.2.1f1"                             | "2019.2.1f1"  | PropertyLocation.script
-        "unityVersion"           | null                   | defaultProjectVersion                    | "null"        | PropertyLocation.none
+        "autoInstallUnityEditor" | true                                  | _                                                  | true          | PropertyLocation.env
+        "autoInstallUnityEditor" | true                                  | _                                                  | 1             | PropertyLocation.env
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'TRUE'        | PropertyLocation.env
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'y'           | PropertyLocation.env
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'yes'         | PropertyLocation.env
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'YES'         | PropertyLocation.env
+        "autoInstallUnityEditor" | true                                  | _                                                  | true          | PropertyLocation.property
+        "autoInstallUnityEditor" | true                                  | _                                                  | 1             | PropertyLocation.property
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'TRUE'        | PropertyLocation.property
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'y'           | PropertyLocation.property
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'yes'         | PropertyLocation.property
+        "autoInstallUnityEditor" | true                                  | _                                                  | 'YES'         | PropertyLocation.property
+        "autoInstallUnityEditor" | true                                  | _                                                  | true          | PropertyLocation.script
+        "autoInstallUnityEditor" | false                                 | _                                                  | null          | PropertyLocation.none
+        "unityInstallBaseDir"    | testPath("/custom/path")              | _                                                  | "path string" | PropertyLocation.env
+        "unityInstallBaseDir"    | testPath("/custom/path")              | _                                                  | "path string" | PropertyLocation.property
+        "unityInstallBaseDir"    | "file('${escapedPath(testPath("/custom/path"))}')" | testPath("/custom/path")                           | "path string" | PropertyLocation.script
+        "unityInstallBaseDir"    | null                                  | testPath("#projectDir#/build/unity_installations") | "null"        | PropertyLocation.none
+        "unityVersion"           | "2017.2.4f5"                          | _                                                  | "2017.2.4f5"  | PropertyLocation.env
+        "unityVersion"           | "2018.3.1b4"                          | _                                                  | "2018.3.1b4"  | PropertyLocation.property
+        "unityVersion"           | "'2019.2.1f1'"                        | "2019.2.1f1"                                       | "2019.2.1f1"  | PropertyLocation.script
+        "unityVersion"           | null                                  | defaultProjectVersion                              | "null"        | PropertyLocation.none
 
         testValue = (expectedValue == _) ? value : expectedValue
-        reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with value '$providedValue'")
+        reason = location.reason() + ((location == PropertyLocation.none) ? "" : " with '$providedValue'")
     }
 
     @Unroll("buildRequiredUnityComponentsProvider returns required components based on build state")

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class UnityVersionManagerPluginIntegrationSpec extends IntegrationSpec {
 
         where:
         taskName     | expectedVersion
-        "uvmVersion" | "0.2.0"
+        "uvmVersion" | "0.2.2"
     }
 
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -21,13 +21,11 @@ import net.wooga.test.unity.ProjectGeneratorRule
 import net.wooga.uvm.Component
 import net.wooga.uvm.UnityVersionManager
 import org.junit.Rule
-import spock.lang.Requires
 import spock.lang.Unroll
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.batchMode.BuildTarget
 import wooga.gradle.unity.tasks.Unity
 
-@Requires({ os.macOs })
 class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
     @Rule
@@ -50,7 +48,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         if (_installedUnityVersions) {
             return _installedUnityVersions
         }
-        def applications = new File("/Applications")
+
+        def applications = baseUnityPath()
         _installedUnityVersions = applications.listFiles(new FilenameFilter() {
             @Override
             boolean accept(File dir, String name) {
@@ -61,8 +60,42 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         }
     }
 
+    File baseUnityPath() {
+        if(isWindows()) {
+            new File("C:\\Program Files")
+        } else if (isMac()) {
+            new File("/Applications")
+        }
+    }
+
+    File unityExecutablePath() {
+        if(isWindows()) {
+            new File("Editor\\Unity.exe")
+        } else if( isMac()) {
+            new File("Unity.app/Contents/MacOS/Unity")
+        }
+    }
+
+    File unityVersion(String version) {
+        def base = new File(baseUnityPath(), "Unity-${version}")
+        new File(base, unityExecutablePath().path)
+    }
+
+    String pathToUnityVersion(String version) {
+        escapedPath(unityVersion(version).absolutePath)
+    }
+
+    static String OS = System.getProperty("os.name").toLowerCase()
+    static boolean isWindows() {
+        return (OS.indexOf("win") >= 0)
+    }
+
+    static boolean isMac() {
+        return (OS.indexOf("mac") >= 0)
+    }
+
     @Unroll
-    def "task :checkUnityInstallation #message and autoSwitchUnityEditor is true"() {
+    def "#message and autoSwitchUnityEditor is true"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -71,9 +104,9 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         uvm.autoSwitchUnityEditor = true
         """.stripIndent()
 
-        and: "and a custom set unity path no matching project version"
+        and: "and a custom set unity path not matching the project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         when:
@@ -84,13 +117,13 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         where:
         editorVersion | expectedUnityPath
-        "2030.1.2f3"  | new File("/Applications/Unity-${installedUnityVersions().last()}")
+        "2030.1.2f3"  | unityVersion(installedUnityVersions().last())
         baseVersion = installedUnityVersions().last()
-        message = "keeps configured path to unity when unity version can't be found"
+        message = "keeps configured path when unity is not found"
     }
 
     @Unroll
-    def "task :checkUnityInstallation #message if autoSwitchUnityEditor is #autoSwitchEnabled"() {
+    def "#message if autoSwitchUnityEditor is #autoSwitchEnabled"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -99,9 +132,9 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         uvm.autoSwitchUnityEditor = ${autoSwitchEnabled}
         """.stripIndent()
 
-        and: "and a custom set unity path no matching project version"
+        and: "and a custom set unity path non matching project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         when:
@@ -112,14 +145,14 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         where:
         editorVersion                    | expectedUnityPath                                                   | autoSwitchEnabled
-        installedUnityVersions().first() | new File("/Applications/Unity-${installedUnityVersions().first()}") | true
-        installedUnityVersions().first() | new File("/Applications/Unity-${installedUnityVersions().last()}")  | false
+        installedUnityVersions().first() | new File(baseUnityPath(),"Unity-${installedUnityVersions().first()}") | true
+        installedUnityVersions().first() | new File(baseUnityPath(),"Unity-${installedUnityVersions().last()}")  | false
         baseVersion = installedUnityVersions().last()
         message = autoSwitchEnabled ? "switches path to unity" : "keeps configured path to unity"
     }
 
     @Unroll
-    def "task :checkUnityInstallation #message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled"() {
+    def "#message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -131,7 +164,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         and: "and a custom set unity path no matching project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         when:
@@ -142,7 +175,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
             def expectedUnityPath = new File(projectDir, installPath)
             result.standardOutput.contains(expectedUnityPath.path)
         } else {
-            result.standardOutput.contains("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+            result.standardOutput.contains("${pathToUnityVersion(baseVersion)}")
         }
 
         cleanup:
@@ -157,10 +190,10 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = installedUnityVersions().last()
-        message = (autoInstallEnabled && autoSwitchEnabled) ? "installs and switches version" : "uses default version"
+        message = (autoInstallEnabled && autoSwitchEnabled) ? "installs & uses version" : "uses default version"
     }
 
-    def "task :checkUnityInstallation fails if version can't be installed"() {
+    def "fails if version can't be installed"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -172,7 +205,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         and: "and a custom set unity path no matching project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         expect:
@@ -184,7 +217,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         baseVersion = installedUnityVersions().last()
     }
 
-    @Unroll("task :checkUnityInstallation #message when task contains buildTarget: #buildTarget")
+    @Unroll("#message when task contains buildTarget: #buildTarget")
     def "checkUnityInstallation installs missing components"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
@@ -197,7 +230,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         and: "and a custom set unity path no matching project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         and: "and a unity installation without components"
@@ -230,7 +263,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         message = expectedComponent ? "installs missing component: ${expectedComponent}" : "installs no component"
     }
 
-    def "task :checkUnityInstallation installs multiple missing components"() {
+    def "installs multiple missing components"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -242,7 +275,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         and: "and a custom set unity path no matching project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         and: "and a unity installation without components"
@@ -279,7 +312,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
     }
 
-    def "task :checkUnityInstallation installs only required components in current build"() {
+    def "installs only required components in current build"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -291,7 +324,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         and: "and a custom set unity path no matching project version"
         buildFile << """
-        unity.unityPath = file("/Applications/Unity-${baseVersion}/Unity.app/Contents/MacOS/Unity")
+        unity.unityPath = file("${pathToUnityVersion(baseVersion)}")
         """.stripIndent()
 
         and: "and a unity installation without components"

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -42,60 +42,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         unityProject.projectDir = projectDir
     }
 
-    static List<String> _installedUnityVersions
-
-    List<String> installedUnityVersions() {
-        if (_installedUnityVersions) {
-            return _installedUnityVersions
-        }
-
-        def applications = baseUnityPath()
-        _installedUnityVersions = applications.listFiles(new FilenameFilter() {
-            @Override
-            boolean accept(File dir, String name) {
-                return name.startsWith("Unity-")
-            }
-        }).collect {
-            it.name.replace("Unity-", "")
-        }
-    }
-
-    File baseUnityPath() {
-        if(isWindows()) {
-            new File("C:\\Program Files")
-        } else if (isMac()) {
-            new File("/Applications")
-        }
-    }
-
-    File unityExecutablePath() {
-        if(isWindows()) {
-            new File("Editor\\Unity.exe")
-        } else if( isMac()) {
-            new File("Unity.app/Contents/MacOS/Unity")
-        }
-    }
-
-    File unityVersion(String version) {
-        def base = new File(baseUnityPath(), "Unity-${version}")
-        new File(base, unityExecutablePath().path)
-    }
-
-    String pathToUnityVersion(String version) {
-        escapedPath(unityVersion(version).absolutePath)
-    }
-
-    static String OS = System.getProperty("os.name").toLowerCase()
-    static boolean isWindows() {
-        return (OS.indexOf("win") >= 0)
-    }
-
-    static boolean isMac() {
-        return (OS.indexOf("mac") >= 0)
-    }
-
-    @Unroll
-    def "#message and autoSwitchUnityEditor is true"() {
+    @Unroll("#message and autoSwitchUnityEditor is true")
+    def "task :checkUnityInstallation #message and autoSwitchUnityEditor is true"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -122,8 +70,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         message = "keeps configured path when unity is not found"
     }
 
-    @Unroll
-    def "#message if autoSwitchUnityEditor is #autoSwitchEnabled"() {
+    @Unroll("#message if autoSwitchUnityEditor is #autoSwitchEnabled")
+    def "task :checkUnityInstallation #message if autoSwitchUnityEditor is #autoSwitchEnabled"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -151,8 +99,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         message = autoSwitchEnabled ? "switches path to unity" : "keeps configured path to unity"
     }
 
-    @Unroll
-    def "#message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled"() {
+    @Unroll("#message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled")
+    def "task :checkUnityInstallation #message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -193,7 +141,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         message = (autoInstallEnabled && autoSwitchEnabled) ? "installs & uses version" : "uses default version"
     }
 
-    def "fails if version can't be installed"() {
+    @Unroll("fails if version can't be installed")
+    def "task :checkUnityInstallation fails if version can't be installed"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -217,8 +166,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         baseVersion = installedUnityVersions().last()
     }
 
-    @Unroll("#message when task contains buildTarget: #buildTarget")
-    def "checkUnityInstallation installs missing components"() {
+    @Unroll("when: #buildTarget")
+    def "task :checkUnityInstallation #message when task contains buildTarget: #buildTarget"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -260,10 +209,11 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         baseVersion = installedUnityVersions().last()
         buildTarget << BuildTarget.values().toList()
         expectedComponent << BuildTarget.values().collect {UnityVersionManagerPlugin.buildTargetToComponent(it)}
-        message = expectedComponent ? "installs missing component: ${expectedComponent}" : "installs no component"
+        message = expectedComponent ? "installs: ${expectedComponent}" : "installs no component"
     }
 
-    def "installs multiple missing components"() {
+    @Unroll("installs missing components")
+    def "task :checkUnityInstallation installs multiple missing components"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 
@@ -312,7 +262,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
     }
 
-    def "installs only required components in current build"() {
+    @Unroll("installs required components")
+    def "task :checkUnityInstallation installs only required components in current build"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmInstallUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmInstallUnityIntegrationSpec.groovy
@@ -28,8 +28,8 @@ class UvmInstallUnityIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
-    @Unroll("task :#taskToRun installs unity version #version #components_message #destination_message with options: #options")
-    def "install unity versions to custom destination"() {
+    @Unroll("installs unity #components_message #destination_message")
+    def "task :#taskToRun installs unity version #version #components_message #destination_message with options: #options"() {
         given: "the destination exists"
         def destinationDir
         if (destination) {
@@ -60,17 +60,17 @@ class UvmInstallUnityIntegrationSpec extends IntegrationSpec {
         "installUnity" | "2017.1.0f1" | []                                 | "build/unity"
         "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | "build/unity"
         "installUnity" | "2017.1.0f3" | [Component.webGl]                  | "build/unity"
-//        "installUnity" | "2017.1.0f1" | []                                 | null
-//        "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | null
-//        "installUnity" | "2017.1.0f3" | [Component.webGl]                  | null
+//      "installUnity" | "2017.1.0f1" | []                                 | null
+//      "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | null
+//      "installUnity" | "2017.1.0f3" | [Component.webGl]                  | null
 
-        components_message = components.size() > 0 ? "with components ${components}" : "without components"
-        destination_message = destination ? "to custom destination" : "to default destination"
+        components_message = components.size() > 0 ? "with components" : ""
+        destination_message = destination ? "" : "to default destination"
         options = (components.collect({"--component=${it}"}) << ((destination) ? "--destination=${destination}" : "") << ((version) ? "--version=${version}" : "")).findAll({it != ""})
     }
 
-    @Unroll("task :#taskToRun installs unity version '#version' set in project #components_message #destination_message with options: #options")
-    def "install unity versions set in project to custom destination"() {
+    @Unroll("installs unity version set in project #components_message")
+    def "task :#taskToRun installs unity version '#version' set in project #components_message #destination_message with options: #options"() {
         given: "the destination exists"
         def destinationDir
         if (destination) {
@@ -106,12 +106,12 @@ class UvmInstallUnityIntegrationSpec extends IntegrationSpec {
         "installUnity" | "2017.1.0f1" | []                                 | "build/unity"
         "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | "build/unity"
         "installUnity" | "2017.1.0f3" | [Component.webGl]                  | "build/unity"
-//        "installUnity" | "2017.1.0f1" | []                                 | null
-//        "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | null
-//        "installUnity" | "2017.1.0f3" | [Component.webGl]                  | null
+//      "installUnity" | "2017.1.0f1" | []                                 | null
+//      "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | null
+//      "installUnity" | "2017.1.0f3" | [Component.webGl]                  | null
 
-        components_message = components.size() > 0 ? "with components ${components}" : "without components"
-        destination_message = destination ? "to custom destination" : "to default destination"
+        components_message = components.size() > 0 ? "with components" : ""
+        destination_message = destination ? "" : "to default destination"
         options = (components.collect({"--component=${it}"}) << ((destination) ? "--destination=${destination}" : "")).findAll({it != ""})
     }
 

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -47,13 +47,13 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
 
     @Override
     void apply(Project project) {
+        def extension = create_and_configure_extension(project)
+
         String osName = System.getProperty("os.name").toLowerCase()
         if (!osName.contains("mac os") && !osName.contains("windows")) {
             logger.warn("This plugin is only supported on macOS and windows.")
             return
         }
-
-        def extension = create_and_configure_extension(project)
 
         project.tasks.create(UVM_VERSION_TASK_NAME, UvmVersion) {
             group = GROUP
@@ -164,7 +164,9 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                 break
             case BuildTarget.win32:
             case BuildTarget.win64:
-                component = Component.windows
+                if(!System.getProperty("os.name").toLowerCase().startsWith("windows")) {
+                    component = Component.windows
+                }
                 break
             default:
                 component = null

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -48,8 +48,8 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         String osName = System.getProperty("os.name").toLowerCase()
-        if (!osName.contains("mac os")) {
-            logger.warn("This plugin is only supported on macOS.")
+        if (!osName.contains("mac os") && !osName.contains("windows")) {
+            logger.warn("This plugin is only supported on macOS and windows.")
             return
         }
 

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -114,8 +114,23 @@ class UvmCheckInstallation extends DefaultTask {
         if(unityExtension.present) {
             logger.info("update path to unity installtion ${installation.location}")
             def extension = unityExtension.get()
-            extension.unityPath = new File(installation.location,"Unity.app/Contents/MacOS/Unity")
+
+            //TODO fix these path after https://github.com/wooga/unity-version-manager-jni/issues/5 has been fixed
+            if (isWindows()) {
+                extension.unityPath = new File(installation.location, "Editor\\Unity.exe")
+            } else if (isMac()) {
+                extension.unityPath = new File(installation.location, "Unity.app/Contents/MacOS/Unity")
+            }
         }
+    }
+
+    static String OS = System.getProperty("os.name").toLowerCase()
+    static boolean isWindows() {
+        return (OS.indexOf("win") >= 0)
+    }
+
+    static boolean isMac() {
+        return (OS.indexOf("mac") >= 0)
     }
 }
 

--- a/src/test/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginSpec.groovy
@@ -51,9 +51,10 @@ class UnityVersionManagerPluginSpec extends ProjectSpec {
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
 
-    def "doesn't apply anything on windows"() {
+    @Unroll
+    def "#message plugin on #platform"() {
         given:
-        System.setProperty("os.name", "windows")
+        System.setProperty("os.name", platform)
 
         assert !project.plugins.hasPlugin(PLUGIN_NAME)
 
@@ -61,6 +62,14 @@ class UnityVersionManagerPluginSpec extends ProjectSpec {
         project.plugins.apply(PLUGIN_NAME)
 
         then:
-        project.tasks.size() == 0
+        (project.tasks.size() > 0) == applies
+
+        where:
+        platform  | applies
+        "mac osx" | true
+        "windows" | true
+        "linux"   | false
+
+        message = (applies) ? "applies" : "doesn't apply"
     }
 }


### PR DESCRIPTION
## Description

This patch enables window support for the unity version manager plugin. Windows is supported with the jni bindings since version `0.2.0`.

## Changes

* ![IMPROVE] enable windows support for plugin

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

