### PR TITLE
Update JNI bindings fetched from jCenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ github {
 }
 
 repositories {
-    mavenCentral()
+    jcenter()
     maven { url "https://dl.bintray.com/wooga/maven" }
     maven { url 'https://repo.gradle.org/gradle/libs-releases' }
 }


### PR DESCRIPTION
## Description

All further versions of `unity-version-manager-jni` will be published to `jcenter`. This patch updates the dependencie and adds `jcenter` as repository.

## Changes

![UPDATE] `unity-version-manager-jni` to `0.3.0`
![IMPROVE] fetch `unity-version-manager-jni` from `jcenter`

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

