### PR TITLE
Remove logic to calculate path to Unity executable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-    compile "net.wooga:unity-version-manager-jni:0.2.2"
+    compile "net.wooga:unity-version-manager-jni:0.4.0"
     compile "gradle.plugin.net.wooga.gradle:atlas-unity:1.+"
     testCompile 'net.wooga.test:unity-project-generator-rule:0.2.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
@@ -38,7 +38,7 @@ class UnityVersionManagerPluginIntegrationSpec extends IntegrationSpec {
 
         where:
         taskName     | expectedVersion
-        "uvmVersion" | "0.2.2"
+        "uvmVersion" | "0.4.0"
     }
 
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -21,6 +21,7 @@ import net.wooga.test.unity.ProjectGeneratorRule
 import net.wooga.uvm.Component
 import net.wooga.uvm.UnityVersionManager
 import org.junit.Rule
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.batchMode.BuildTarget
@@ -99,6 +100,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         message = autoSwitchEnabled ? "switches path to unity" : "keeps configured path to unity"
     }
 
+    @IgnoreIf({ System.getProperty("os.name").contains("windows") })
     @Unroll("#message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled")
     def "task :checkUnityInstallation #message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled"() {
         given: "A project with a mocked unity version"

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -21,7 +21,6 @@ import net.wooga.test.unity.ProjectGeneratorRule
 import net.wooga.uvm.Component
 import net.wooga.uvm.UnityVersionManager
 import org.junit.Rule
-import spock.lang.IgnoreIf
 import spock.lang.Unroll
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.batchMode.BuildTarget
@@ -100,8 +99,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         message = autoSwitchEnabled ? "switches path to unity" : "keeps configured path to unity"
     }
 
-    @IgnoreIf({ System.getProperty("os.name").contains("windows") })
-    @Unroll("#message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled")
+
+    @Unroll("#message")
     def "task :checkUnityInstallation #message if autoInstallUnityEditor is #autoInstallEnabled and autoSwitchUnityEditor is #autoSwitchEnabled"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -114,23 +114,8 @@ class UvmCheckInstallation extends DefaultTask {
         if(unityExtension.present) {
             logger.info("update path to unity installtion ${installation.location}")
             def extension = unityExtension.get()
-
-            //TODO fix these path after https://github.com/wooga/unity-version-manager-jni/issues/5 has been fixed
-            if (isWindows()) {
-                extension.unityPath = new File(installation.location, "Editor\\Unity.exe")
-            } else if (isMac()) {
-                extension.unityPath = new File(installation.location, "Unity.app/Contents/MacOS/Unity")
-            }
+            extension.unityPath = installation.executable
         }
-    }
-
-    static String OS = System.getProperty("os.name").toLowerCase()
-    static boolean isWindows() {
-        return (OS.indexOf("win") >= 0)
-    }
-
-    static boolean isMac() {
-        return (OS.indexOf("mac") >= 0)
     }
 }
 


### PR DESCRIPTION
## Description

This patch removes the custom logic to calcualate the path to the unity executable. The newest version (0.4.0) of `unity-version-manager-jni` provides a getter. see: https://github.com/wooga/unity-version-manager-jni/pull/10

## Changes

![REMOVE] logic to calculate path to Unity executable

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

