### PR TITLE
Update unity-version-manager-jni to to stable release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
 }
 
 dependencies {
-    compile "net.wooga:unity-version-manager-jni:0.4.0"
+    compile "net.wooga:unity-version-manager-jni:1.+"
     compile "gradle.plugin.net.wooga.gradle:atlas-unity:1.+"
     testCompile 'net.wooga.test:unity-project-generator-rule:0.2.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginIntegrationSpec.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.unity.version.manager
 
-import spock.lang.Unroll
+
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.tasks.Unity
 
@@ -28,19 +28,6 @@ class UnityVersionManagerPluginIntegrationSpec extends IntegrationSpec {
             ${applyPlugin(UnityVersionManagerPlugin)}
         """.stripIndent()
     }
-
-    @Unroll
-    def "task :#taskName prints uvm version"() {
-        given: "default plugin setup"
-
-        expect:
-        runTasksSuccessfully(taskName).standardOutput.contains("uvm core version: ${expectedVersion}")
-
-        where:
-        taskName     | expectedVersion
-        "uvmVersion" | "0.4.0"
-    }
-
 
     def "creates hooks into atlas-unity when plugin is applied"() {
         given: "a project with atlas-unity applied"


### PR DESCRIPTION
## Description

[unity-version-manager-jni] got released as first stable version. This patch targets this new release.

## Changes

![UPDATE] [unity-version-manager-jni] to stable version `1.+`

[unity-version-manager-jni]: https://github.com/wooga/unity-version-manager-jni

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

