### PR TITLE
Add Linux support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,5 +21,5 @@
 
 withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token')]) {
 
-    buildGradlePlugin(plaforms:['osx', 'windows'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity&&fast')
+    buildGradlePlugin(plaforms:['osx','windows','linux'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity&&fast')
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
@@ -73,10 +73,12 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
     }
 
     File baseUnityPath() {
-        if (isWindows()) {
+        if(isWindows()) {
             new File("C:\\Program Files")
         } else if (isMac()) {
             new File("/Applications")
+        } else if (isLinux()) {
+            new File("${System.getenv('HOME')}/.local/share")
         }
     }
 
@@ -85,6 +87,8 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
             new File("Editor\\Unity.exe")
         } else if (isMac()) {
             new File("Unity.app/Contents/MacOS/Unity")
+        } else if (isLinux()) {
+            new File("Editor/Unity")
         }
     }
 
@@ -105,6 +109,10 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
 
     static boolean isMac() {
         return (OS.indexOf("mac") >= 0)
+    }
+
+    static boolean isLinux() {
+        return (OS.indexOf("linux") >= 0)
     }
 
     static String testPath(String path) {

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -21,6 +21,7 @@ import net.wooga.test.unity.ProjectGeneratorRule
 import net.wooga.uvm.Component
 import net.wooga.uvm.UnityVersionManager
 import org.junit.Rule
+import spock.lang.IgnoreIf
 import spock.lang.Unroll
 import wooga.gradle.unity.UnityPlugin
 import wooga.gradle.unity.batchMode.BuildTarget
@@ -40,6 +41,14 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         """.stripIndent()
         unityProject.projectDir = projectDir
+    }
+
+    static String unityTestVersion() {
+        if (isLinux()) {
+            return "2019.1.0b1"
+        }
+
+        "2017.1.0f1"
     }
 
     @Unroll("#message and autoSwitchUnityEditor is true")
@@ -92,9 +101,9 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         result.standardOutput.contains(expectedUnityPath.path)
 
         where:
-        editorVersion                    | expectedUnityPath                                                   | autoSwitchEnabled
-        installedUnityVersions().first() | new File(baseUnityPath(),"Unity-${installedUnityVersions().first()}") | true
-        installedUnityVersions().first() | new File(baseUnityPath(),"Unity-${installedUnityVersions().last()}")  | false
+        editorVersion                    | expectedUnityPath                                                      | autoSwitchEnabled
+        installedUnityVersions().first() | new File(baseUnityPath(), "Unity-${installedUnityVersions().first()}") | true
+        installedUnityVersions().first() | new File(baseUnityPath(), "Unity-${installedUnityVersions().last()}")  | false
         baseVersion = installedUnityVersions().last()
         message = autoSwitchEnabled ? "switches path to unity" : "keeps configured path to unity"
     }
@@ -131,11 +140,11 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        editorVersion | autoInstallEnabled | autoSwitchEnabled
-        "2017.1.0f1"  | false              | false
-        "2017.1.0f1"  | true               | false
-        "2017.1.0f1"  | false              | true
-        "2017.1.0f1"  | true               | true
+        editorVersion      | autoInstallEnabled | autoSwitchEnabled
+        unityTestVersion() | false              | false
+        unityTestVersion() | true               | false
+        unityTestVersion() | false              | true
+        unityTestVersion() | true               | true
 
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = installedUnityVersions().last()
@@ -167,6 +176,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         baseVersion = installedUnityVersions().last()
     }
 
+    @IgnoreIf({os.linux})
     @Unroll("when: #buildTarget")
     def "task :checkUnityInstallation #message when task contains buildTarget: #buildTarget"() {
         given: "A project with a mocked unity version"
@@ -194,7 +204,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         runTasksSuccessfully("customUnity")
 
         then:
-        if(expectedComponent) {
+        if (expectedComponent) {
             installation.components.contains(expectedComponent)
         } else {
             installation.components.size() == 0
@@ -205,11 +215,11 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        editorVersion = "2017.1.0f1"
+        editorVersion = unityTestVersion()
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = installedUnityVersions().last()
         buildTarget << BuildTarget.values().toList()
-        expectedComponent << BuildTarget.values().collect {UnityVersionManagerPlugin.buildTargetToComponent(it)}
+        expectedComponent << BuildTarget.values().collect { UnityVersionManagerPlugin.buildTargetToComponent(it) }
         message = expectedComponent ? "installs: ${expectedComponent}" : "installs no component"
     }
 
@@ -253,7 +263,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        editorVersion = "2017.1.0f1"
+        editorVersion = unityTestVersion()
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = installedUnityVersions().last()
         buildTarget1 = BuildTarget.ios
@@ -303,7 +313,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        editorVersion = "2017.1.0f1"
+        editorVersion = unityTestVersion()
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = installedUnityVersions().last()
         buildTarget1 = BuildTarget.ios

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmInstallUnityIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmInstallUnityIntegrationSpec.groovy
@@ -28,6 +28,14 @@ class UvmInstallUnityIntegrationSpec extends IntegrationSpec {
         """.stripIndent()
     }
 
+    static String unityTestVersion() {
+        if (isLinux()) {
+            return "2019.1.0b"
+        }
+
+        "2017.1.0f"
+    }
+
     @Unroll("installs unity #components_message #destination_message")
     def "task :#taskToRun installs unity version #version #components_message #destination_message with options: #options"() {
         given: "the destination exists"
@@ -56,17 +64,21 @@ class UvmInstallUnityIntegrationSpec extends IntegrationSpec {
         }
 
         where:
-        taskToRun      | version      | components                         | destination
-        "installUnity" | "2017.1.0f1" | []                                 | "build/unity"
-        "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | "build/unity"
-        "installUnity" | "2017.1.0f3" | [Component.webGl]                  | "build/unity"
+        taskToRun      | version                  | components                         | destination
+        "installUnity" | "${unityTestVersion()}1" | []                                 | "build/unity"
+        "installUnity" | "${unityTestVersion()}2" | [Component.android, Component.ios] | "build/unity"
+        "installUnity" | "${unityTestVersion()}3" | [Component.webGl]                  | "build/unity"
 //      "installUnity" | "2017.1.0f1" | []                                 | null
 //      "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | null
 //      "installUnity" | "2017.1.0f3" | [Component.webGl]                  | null
 
         components_message = components.size() > 0 ? "with components" : ""
         destination_message = destination ? "" : "to default destination"
-        options = (components.collect({"--component=${it}"}) << ((destination) ? "--destination=${destination}" : "") << ((version) ? "--version=${version}" : "")).findAll({it != ""})
+        options = (components.collect({
+            "--component=${it}"
+        }) << ((destination) ? "--destination=${destination}" : "") << ((version) ? "--version=${version}" : "")).findAll({
+            it != ""
+        })
     }
 
     @Unroll("installs unity version set in project #components_message")
@@ -102,17 +114,19 @@ class UvmInstallUnityIntegrationSpec extends IntegrationSpec {
         }
 
         where:
-        taskToRun      | version      | components                         | destination
-        "installUnity" | "2017.1.0f1" | []                                 | "build/unity"
-        "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | "build/unity"
-        "installUnity" | "2017.1.0f3" | [Component.webGl]                  | "build/unity"
+        taskToRun      | version                  | components                         | destination
+        "installUnity" | "${unityTestVersion()}1" | []                                 | "build/unity"
+        "installUnity" | "${unityTestVersion()}2" | [Component.android, Component.ios] | "build/unity"
+        "installUnity" | "${unityTestVersion()}3" | [Component.webGl]                  | "build/unity"
 //      "installUnity" | "2017.1.0f1" | []                                 | null
 //      "installUnity" | "2017.1.0f2" | [Component.android, Component.ios] | null
 //      "installUnity" | "2017.1.0f3" | [Component.webGl]                  | null
 
         components_message = components.size() > 0 ? "with components" : ""
         destination_message = destination ? "" : "to default destination"
-        options = (components.collect({"--component=${it}"}) << ((destination) ? "--destination=${destination}" : "")).findAll({it != ""})
+        options = (components.collect({
+            "--component=${it}"
+        }) << ((destination) ? "--destination=${destination}" : "")).findAll({ it != "" })
     }
 
     def "help prints commandline description for installUnity"() {

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -50,8 +50,8 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
         def extension = create_and_configure_extension(project)
 
         String osName = System.getProperty("os.name").toLowerCase()
-        if (!osName.contains("mac os") && !osName.contains("windows")) {
-            logger.warn("This plugin is only supported on macOS and windows.")
+        if (!osName.contains("mac os") && !osName.contains("windows") && !osName.contains("linux")) {
+            logger.warn("This plugin is only supported on macOS and windows and linux.")
             return
         }
 

--- a/src/test/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginSpec.groovy
+++ b/src/test/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPluginSpec.groovy
@@ -68,7 +68,8 @@ class UnityVersionManagerPluginSpec extends ProjectSpec {
         platform  | applies
         "mac osx" | true
         "windows" | true
-        "linux"   | false
+        "linux"   | true
+        "bsd"     | false
 
         message = (applies) ? "applies" : "doesn't apply"
     }


### PR DESCRIPTION
## Description

This patch adds linux support by upgrading to the latest version of the [unity-version-manager-jni] library. The jenkins pipeline is adjusted to run the test suite on a custom AWS machine. Most tests had to be adjusted to test with a unity 2019 editor because not all 2017 versions are installable. I had to create a switch because the windows and macOS tests had issues with the 2019 version.

## Changes

![ADD] ![LINUX] support

[unity-version-manager-jni]:    https://github.com/wooga/unity-version-manager-jni

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:http://atlas-resources.wooga.com/icons/icon_linux.svg "Linux"

