### PR TITLE
Bootstrap preinstalled Unity version in tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,5 +21,5 @@
 
 withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token')]) {
 
-    buildGradlePlugin(plaforms:['osx', 'linux'], coverallsToken: coveralls_token, testEnvironment: [])
+    buildGradlePlugin(plaforms:['osx', 'linux'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'primary')
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,5 +21,5 @@
 
 withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token')]) {
 
-    buildGradlePlugin(plaforms:['osx','windows','linux'], coverallsToken: coveralls_token, testEnvironment: [], labels: 'unity&&fast')
+    buildGradlePlugin(plaforms:['osx', 'linux'], coverallsToken: coveralls_token, testEnvironment: [])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '1.1.0'
+    id 'net.wooga.plugins' version '1.4.0'
 }
 
 group 'net.wooga.gradle'
@@ -51,4 +51,5 @@ dependencies {
     compile "gradle.plugin.net.wooga.gradle:atlas-unity:1.+"
     testCompile 'net.wooga.test:unity-project-generator-rule:0.2.0'
     testCompile 'com.github.stefanbirkner:system-rules:1.18.0'
+    testCompile "com.wooga.spock.extensions:spock-unity-version-manager-extension:0.1.0"
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/IntegrationSpec.groovy
@@ -17,9 +17,12 @@
 
 package wooga.gradle.unity.version.manager
 
+import com.wooga.spock.extensions.uvm.UnityInstallation
+import net.wooga.uvm.Installation
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 import org.junit.contrib.java.lang.system.ProvideSystemProperty
+import spock.lang.Shared
 
 import static groovy.json.StringEscapeUtils.escapeJava
 
@@ -30,6 +33,14 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
 
     @Rule
     ProvideSystemProperty properties = new ProvideSystemProperty("ignoreDeprecations", "true")
+
+    @Shared
+    @UnityInstallation(version="2018.4.19f1", basePath = "build/unity", cleanup = true)
+    Installation preInstalledUnity2018_4_19f1
+
+    @Shared
+    @UnityInstallation(version="2018.4.18f1", basePath = "build/unity", cleanup = true)
+    Installation preInstalledUnity2018_4_18f1
 
     def setup() {
         def gradleVersion = System.getenv("GRADLE_VERSION")
@@ -73,13 +84,7 @@ class IntegrationSpec extends nebula.test.IntegrationSpec {
     }
 
     File baseUnityPath() {
-        if(isWindows()) {
-            new File("C:\\Program Files")
-        } else if (isMac()) {
-            new File("/Applications")
-        } else if (isLinux()) {
-            new File("${System.getenv('HOME')}/.local/share")
-        }
+        new File("build/unity")
     }
 
     File unityExecutablePath() {

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -306,7 +306,6 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         runTasksSuccessfully("customUnity")
 
         then:
-        installation.components.size() == 1
         installation.components.contains(expectedComponent)
 
         cleanup:

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmListInstallatonsIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmListInstallatonsIntegrationSpec.groovy
@@ -17,7 +17,10 @@
 
 package wooga.gradle.unity.version.manager
 
+import com.wooga.spock.extensions.uvm.UnityInstallation
+import net.wooga.uvm.Installation
 import net.wooga.uvm.UnityVersionManager
+import spock.lang.Shared
 import spock.lang.Unroll
 
 class UvmListInstallatonsIntegrationSpec extends IntegrationSpec {


### PR DESCRIPTION
## Description

Instead of using a unityversion being installed on the test system this patch ensures a unity installation at test runtime. It uses a spock extension library [spock-unity-version-manager-extension].

## Changes

* ![IMPROVE] bootstrap preinstalled Unity versions in tests

[spock-unity-version-manager-extension]: https://github.com/wooga/spock-unity-version-manager-extension

[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"

