### PR TITLE
Improve buildRequiredUnityComponents property convention

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -114,29 +114,28 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
         extension.autoSwitchUnityEditor.convention(UnityVersionManagerConventions.autoSwitchUnityEditor.getBooleanValueProvider(project))
         extension.autoInstallUnityEditor.convention(UnityVersionManagerConventions.autoInstallUnityEditor.getBooleanValueProvider(project))
 
-            extension.buildRequiredUnityComponents.set(project.provider({
-                project.tasks.withType(UnityTask)
-                        .findAll({
-                            try {
-                                return project.gradle.taskGraph.hasTask(it)
-                            } catch (IllegalStateException ignored) {
-                                logger.warn("try to filter required build components to early. Filter not applied")
-                            }
-                            true
-                        })
-                        .collect({
-                    BuildTargetToComponent.buildTargetToComponent(it.buildTarget)
-                })
-            }).flatMap(new Transformer<Provider<List<Component>>, List<Provider<Component>>>() {
-                @Override
-                Provider<List<Component>> transform(List<Provider<Component>> providers) {
-                    project.provider({
-                        providers.collect {
-                            it.getOrElse(Component.unknown)
-                        }.findAll {it != Component.unknown }
+        extension.buildRequiredUnityComponents.convention(project.provider({
+            project.tasks.withType(UnityTask)
+                    .findAll({
+                        try {
+                            return project.gradle.taskGraph.hasTask(it)
+                        } catch (IllegalStateException ignored) {
+                        }
+                        true
                     })
-                }
-            }))
+                    .collect({
+                BuildTargetToComponent.buildTargetToComponent(it.buildTarget)
+            })
+        }).flatMap(new Transformer<Provider<List<Component>>, List<Provider<Component>>>() {
+            @Override
+            Provider<List<Component>> transform(List<Provider<Component>> providers) {
+                project.provider({
+                    providers.collect {
+                        it.getOrElse(Component.unknown)
+                    }.findAll {it != Component.unknown }
+                })
+            }
+        }))
         extension
     }
 

--- a/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/tasks/UvmCheckInstallation.groovy
@@ -89,7 +89,7 @@ class UvmCheckInstallation extends DefaultTask {
 
         if (autoSwitchUnityEditor.get() && autoInstallUnityEditor.get() && needInstall) {
             def destination = unityInstallBaseDir.file(version).get().asFile
-            def components = buildRequiredUnityComponents.get().toArray() as Component[]
+            def components = buildRequiredUnityComponents.getOrElse(new HashSet<Component>()).toArray() as Component[]
             logger.info("install unity ${version}")
             if(components.size() > 0) {
                 logger.info("with components: ")


### PR DESCRIPTION
## Description

The `buildRequiredUnityComponents` property in the extension is very time sensitive. The final value can only be calculated after the task graph has been created to filter out any component for potential Unity tasks not in the execution list. This was also the case before the gradle upgrade. I removed the warning log as it is fired now multiple times. But this project actually has a test that covers the case of the filtering and verifies the change of the values depending when in the gradle lifecycle the value was requested.

## Changes

* ![IMPROVE] `buildRequiredUnityComponents` property convention

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"

