### PR TITLE
Use PropertyLookup class from com.wooga.gradle:gradle-commons

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ repositories {
 dependencies {
     implementation "net.wooga:unity-version-manager-jni:(1,2]"
     implementation "gradle.plugin.net.wooga.gradle:atlas-unity:(2,3]"
+    implementation "com.wooga.gradle:gradle-commons:0.1.0"
     testImplementation 'net.wooga.test:unity-project-generator-rule:0.3.0'
     testImplementation "com.wooga.spock.extensions:spock-unity-version-manager-extension:0.2.0"
 }

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConventions.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerConventions.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.unity.version.manager
 
-import wooga.gradle.unity.utils.PropertyLookup
+import com.wooga.gradle.PropertyLookup
 
 class UnityVersionManagerConventions {
 


### PR DESCRIPTION
## Description

The `PropertyLookup` class has a new location in the library `com.wooga.grale:gradle-commons`. We should use this library directly instead of using the exposed API from `net.wooga.unity` plugin

Changes
=======

* ![IMPROVE] use `PropertyLookup` class from `com.wooga.gradle:gradle-commons`

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
