### PR TITLE
Support 2019/2020/2021 Linux, MacOS and Windows components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
     implementation 'net.wooga:unity-version-manager-jni:[1.4.1,2)'
     implementation "gradle.plugin.net.wooga.gradle:atlas-unity:[2,3)"
     implementation "com.wooga.gradle:gradle-commons:0.1.0"
+    implementation 'org.apache.maven:maven-artifact:3.8.1'
     testImplementation 'net.wooga.test:unity-project-generator-rule:0.3.0'
     testImplementation "com.wooga.spock.extensions:spock-unity-version-manager-extension:0.2.0"
 }

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -222,7 +222,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         ""        | unityTestVersion()  | BuildTarget.win64     | [Component.windowsMono]
         "linux"   | unityTestVersion()  | BuildTarget.linux64   | [Component.linuxIL2CPP]
         "linux"   | unityTestVersion()  | BuildTarget.osx       | [Component.macMono]
-        "linux"   | "2018.4.30f1"       | BuildTarget.linux     | [Component.linux]
+        "mac os"  | "2018.4.30f1"       | BuildTarget.linux     | [Component.linux]
         "mac os"  | unityTestVersion()  | BuildTarget.linux64   | [Component.linuxMono, Component.linuxIL2CPP]
         "mac os"  | unityTestVersion()  | BuildTarget.osx       | [Component.macMono, Component.macIL2CPP]
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -222,6 +222,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         ""        | unityTestVersion()  | BuildTarget.win64     | [Component.windowsMono]
         "linux"   | unityTestVersion()  | BuildTarget.linux64   | [Component.linuxIL2CPP]
         "linux"   | unityTestVersion()  | BuildTarget.osx       | [Component.macMono]
+        "linux"   | "2018.4.30f1"       | BuildTarget.linux     | [Component.linux]
         "mac os"  | unityTestVersion()  | BuildTarget.linux64   | [Component.linuxMono, Component.linuxIL2CPP]
         "mac os"  | unityTestVersion()  | BuildTarget.osx       | [Component.macMono, Component.macIL2CPP]
 

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -200,7 +200,9 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         buildFile << "customUnity.buildTarget = '${buildTarget}'"
 
         when:
-        runTasksSuccessfully("customUnity")
+        if (System.getProperty("os.name").toLowerCase().contains(platform)) {
+            runTasksSuccessfully("customUnity")
+        }
 
         then:
         if (expectedComponent) {
@@ -214,11 +216,14 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        editorVersion       | buildTarget           | expectedComponent
-        unityTestVersion()  | BuildTarget.android   | [Component.android]
-        unityTestVersion()  | BuildTarget.ios       | [Component.ios]
-        unityTestVersion()  | BuildTarget.linux64   | [Component.linuxMono, Component.linuxIL2CPP]
-        unityTestVersion()  | BuildTarget.win64     | [Component.windowsMono]
+        platform  | editorVersion       | buildTarget           | expectedComponent
+        ""        | unityTestVersion()  | BuildTarget.android   | [Component.android]
+        ""        | unityTestVersion()  | BuildTarget.ios       | [Component.ios]
+        ""        | unityTestVersion()  | BuildTarget.win64     | [Component.windowsMono]
+        "linux"   | unityTestVersion()  | BuildTarget.linux64   | [Component.linuxIL2CPP]
+        "linux"   | unityTestVersion()  | BuildTarget.osx       | [Component.macMono]
+        "mac os"  | unityTestVersion()  | BuildTarget.linux64   | [Component.linuxMono, Component.linuxIL2CPP]
+        "mac os"  | unityTestVersion()  | BuildTarget.osx       | [Component.macMono, Component.macIL2CPP]
 
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = preInstalledUnity2019_4_31f1

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -205,8 +205,8 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         }
 
         then:
-        if (expectedComponent) {
-            installation.components.equals(expectedComponent)
+        if (expectedComponents) {
+            installation.components.equals(expectedComponents)
         } else {
             installation.components.size() == 0
         }
@@ -216,7 +216,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        platform  | editorVersion       | buildTarget           | expectedComponent
+        platform  | editorVersion       | buildTarget           | expectedComponents
         ""        | unityTestVersion()  | BuildTarget.android   | [Component.android]
         ""        | unityTestVersion()  | BuildTarget.ios       | [Component.ios]
         ""        | unityTestVersion()  | BuildTarget.win64     | [Component.windowsMono]
@@ -227,7 +227,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = preInstalledUnity2019_4_31f1
-        message = expectedComponent ? "installs: ${expectedComponent}" : "installs no component"
+        message = expectedComponents ? "installs: ${expectedComponents}" : "installs no component"
     }
 
     @Unroll("installs missing components")

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -204,7 +204,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         then:
         if (expectedComponent) {
-            installation.components.contains(expectedComponent)
+            installation.components.equals(expectedComponent)
         } else {
             installation.components.size() == 0
         }
@@ -215,10 +215,10 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
 
         where:
         editorVersion       | buildTarget           | expectedComponent
-        unityTestVersion()  | BuildTarget.android   | Component.android
-        unityTestVersion()  | BuildTarget.ios       | Component.ios
-        unityTestVersion()  | BuildTarget.linux64   | Component.linuxMono
-        unityTestVersion()  | BuildTarget.win64     | Component.windowsMono
+        unityTestVersion()  | BuildTarget.android   | [Component.android]
+        unityTestVersion()  | BuildTarget.ios       | [Component.ios]
+        unityTestVersion()  | BuildTarget.linux64   | [Component.linuxMono, Component.linuxIL2CPP]
+        unityTestVersion()  | BuildTarget.win64     | [Component.windowsMono]
 
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = preInstalledUnity2019_4_31f1

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -176,7 +176,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         baseVersion = preInstalledUnity2019_4_31f1
     }
 
-    @Unroll("when: #buildTarget")
+    @Unroll("when: #buildTarget #message")
     def "task :checkUnityInstallation #message when task contains buildTarget: #buildTarget"() {
         given: "A project with a mocked unity version"
         unityProject.setProjectVersion(editorVersion)
@@ -280,7 +280,6 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         editorVersion = unityTestVersion()
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = preInstalledUnity2019_4_31f1
-
         buildTarget1 = BuildTarget.ios
         buildTarget2 = BuildTarget.android
         expectedComponent1 = Component.ios

--- a/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
+++ b/src/integrationTest/groovy/wooga/gradle/unity/version/manager/UvmCheckInstalltionIntegrationSpec.groovy
@@ -176,7 +176,6 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         baseVersion = preInstalledUnity2019_4_31f1
     }
 
-    @Ignore("This test does not scale over multiple versions of unity")
     @Unroll("when: #buildTarget")
     def "task :checkUnityInstallation #message when task contains buildTarget: #buildTarget"() {
         given: "A project with a mocked unity version"
@@ -215,11 +214,14 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         new File(projectDir, installPath).deleteDir()
 
         where:
-        editorVersion = unityTestVersion()
+        editorVersion       | buildTarget           | expectedComponent
+        unityTestVersion()  | BuildTarget.android   | Component.android
+        unityTestVersion()  | BuildTarget.ios       | Component.ios
+        unityTestVersion()  | BuildTarget.linux64   | Component.linuxMono
+        unityTestVersion()  | BuildTarget.win64     | Component.windowsMono
+
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = preInstalledUnity2019_4_31f1
-        buildTarget << BuildTarget.values().toList()
-        expectedComponent << BuildTarget.values().collect { UnityVersionManagerPlugin.buildTargetToComponent(it) }
         message = expectedComponent ? "installs: ${expectedComponent}" : "installs no component"
     }
 
@@ -272,6 +274,7 @@ class UvmCheckInstalltionIntegrationSpec extends IntegrationSpec {
         editorVersion = unityTestVersion()
         installPath = "build/unity_installations/${editorVersion}"
         baseVersion = preInstalledUnity2019_4_31f1
+
         buildTarget1 = BuildTarget.ios
         buildTarget2 = BuildTarget.android
         expectedComponent1 = Component.ios

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -182,18 +182,18 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                 case "linux":
                 case "linux64":
                 case "linuxuniversal":
-                    if (!isLinux) components.add(Component.linuxMono)
                     // all three platforms support linux I2CPP (cross-)compilation
-                    if (isLinux || isWindows || isMac) components.(Component.linuxIL2CPP)
+                    components.(Component.linuxIL2CPP)
+                    if (!isLinux) components.add(Component.linuxMono)
                     break
                 case 'osxuniversal':
-                    if (!isMac) components.add(Component.macMono)
                     if (isMac) components.add(Component.macIL2CPP)
+                    else components.add(Component.macMono)
                     break
                 case "win32":
                 case "win64":
-                    if (!isWindows) components.add(Component.windowsMono)
                     if (isWindows) components.add(Component.windowsIL2CCP)
+                    else components.add(Component.windowsMono)
                     break
             }
         } else if (version.majorVersion == 2018) {
@@ -204,13 +204,13 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                     if (!isLinux) components.add(Component.linux)
                     break
                 case 'osxuniversal':
-                    if (!isMac) components.add(Component.macMono)
                     if (isMac) components.add(Component.macIL2CPP)
+                    else components.add(Component.macMono)
                     break
                 case "win32":
                 case "win64":
-                    if (!isWindows) components.add(Component.windowsMono)
                     if (isWindows) components.add(Component.windowsIL2CCP)
+                    else components.add(Component.windowsMono)
                     break
             }
         } else {

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -17,7 +17,7 @@
 
 package wooga.gradle.unity.version.manager
 
-import com.wooga.gradle.PlatformUtils
+import wooga.gradle.unity.utils.PlatformUtils
 import net.wooga.uvm.Component
 import net.wooga.uvm.UnityVersionManager
 import org.gradle.api.Action

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -194,6 +194,23 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                     if (isWindows) components.add(Component.windowsIL2CCP)
                     break
             }
+        } else if (version.majorVersion == 2018) {
+            switch (target.toLowerCase()) {
+                case "linux":
+                case "linux64":
+                case "linuxuniversal":
+                    if (!isLinux) components.add(Component.linux)
+                    break
+                case 'osxuniversal':
+                    if (!isMac) components.add(Component.macMono)
+                    if (isMac) components.add(Component.macIL2CPP)
+                    break
+                case "win32":
+                case "win64":
+                    if (!isWindows) components.add(Component.windowsMono)
+                    if (isWindows) components.add(Component.windowsIL2CCP)
+                    break
+            }
         } else {
             switch (target.toLowerCase()) {
                 case "linux":

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -139,12 +139,14 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
         extension
     }
 
+    @Deprecated
     static Component buildTargetToComponent(BuildTarget target) {
         buildTargetToComponent(target.toString())
     }
 
+    @Deprecated
     static Component buildTargetToComponent(String target) {
-        buildTargetToComponents(target, "2018").first()
+        buildTargetToComponents(target, "2017.1.1f1").first()
     }
 
     static List<Component> buildTargetToComponents(String target, String versionString) {

--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -17,6 +17,7 @@
 
 package wooga.gradle.unity.version.manager
 
+import com.wooga.gradle.PlatformUtils
 import net.wooga.uvm.Component
 import net.wooga.uvm.UnityVersionManager
 import org.gradle.api.Action
@@ -38,7 +39,6 @@ import wooga.gradle.unity.version.manager.tasks.UvmCheckInstallation
 import wooga.gradle.unity.version.manager.tasks.UvmInstallUnity
 import wooga.gradle.unity.version.manager.tasks.UvmListInstallations
 import wooga.gradle.unity.version.manager.tasks.UvmVersion
-import org.apache.maven.artifact.versioning.ArtifactVersion
 import org.apache.maven.artifact.versioning.DefaultArtifactVersion
 
 class UnityVersionManagerPlugin implements Plugin<Project> {
@@ -151,10 +151,6 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
 
     static List<Component> buildTargetToComponents(String target, String versionString) {
         def version = new DefaultArtifactVersion(versionString.split(/f|p|b|a/).first().toString())
-        def osName = System.getProperty("os.name").toLowerCase()
-        def isWindows = osName.contains("windows")
-        def isLinux = osName.contains("linux")
-        def isMac = osName.contains("mac os")
 
         def components = []
         switch (target.toLowerCase()) {
@@ -184,15 +180,15 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                 case "linuxuniversal":
                     // all three platforms support linux I2CPP (cross-)compilation
                     components.(Component.linuxIL2CPP)
-                    if (!isLinux) components.add(Component.linuxMono)
+                    if (!PlatformUtils.isLinux()) components.add(Component.linuxMono)
                     break
                 case 'osxuniversal':
-                    if (isMac) components.add(Component.macIL2CPP)
+                    if (PlatformUtils.isMac()) components.add(Component.macIL2CPP)
                     else components.add(Component.macMono)
                     break
                 case "win32":
                 case "win64":
-                    if (isWindows) components.add(Component.windowsIL2CCP)
+                    if (PlatformUtils.isWindows()) components.add(Component.windowsIL2CCP)
                     else components.add(Component.windowsMono)
                     break
             }
@@ -201,15 +197,15 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                 case "linux":
                 case "linux64":
                 case "linuxuniversal":
-                    if (!isLinux) components.add(Component.linux)
+                    if (!PlatformUtils.isLinux()) components.add(Component.linux)
                     break
                 case 'osxuniversal':
-                    if (isMac) components.add(Component.macIL2CPP)
+                    if (PlatformUtils.isMac()) components.add(Component.macIL2CPP)
                     else components.add(Component.macMono)
                     break
                 case "win32":
                 case "win64":
-                    if (isWindows) components.add(Component.windowsIL2CCP)
+                    if (PlatformUtils.isWindows()) components.add(Component.windowsIL2CCP)
                     else components.add(Component.windowsMono)
                     break
             }
@@ -218,14 +214,14 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
                 case "linux":
                 case "linux64":
                 case "linuxuniversal":
-                    if (!isLinux) components.add(Component.linux)
+                    if (!PlatformUtils.isLinux()) components.add(Component.linux)
                     break
                 case 'osxuniversal':
-                    if (!isMac) components.add(Component.mac)
+                    if (!PlatformUtils.isMac()) components.add(Component.mac)
                     break
                 case "win32":
                 case "win64":
-                    if (!isWindows) components.add(Component.windows)
+                    if (!PlatformUtils.isWindows()) components.add(Component.windows)
                     break
             }
         }


### PR DESCRIPTION
## Description
Add support to install the correct Unity components for Linux, MacOS and Windows standalone builds on Unity 2018 till 2021.1.

## Changes
* ![IMPROVE] make `buildTargetToComponents` version aware 
* ![ADD] `buildTarget` mapping to `Component.<x>Mono` and `Component.<x>IL2CPP` 

[NEW]:https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:http://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:http://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:http://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:http://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:http://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:http://resources.atlas.wooga.com/icons/icon_break.svg "Break"
[REMOVE]:http://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:http://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:http://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:http://resources.atlas.wooga.com/icons/icon_webGL.svg "Web:GL"
[GRADLE]:http://resources.atlas.wooga.com/icons/icon_gradle.svg "Gradle"
[UNITY]:http://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"

