### PR TITLE
Fix iOSSupport module installation destination on linux

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '2.2.0'
+    id 'net.wooga.plugins' version '2.2.4'
 }
 
 group 'net.wooga.gradle'
@@ -46,8 +46,8 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.wooga:unity-version-manager-jni:1.4.0'
-    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:(2,3]"
+    implementation 'net.wooga:unity-version-manager-jni:[1.4.1,2)'
+    implementation "gradle.plugin.net.wooga.gradle:atlas-unity:[2,3)"
     implementation "com.wooga.gradle:gradle-commons:0.1.0"
     testImplementation 'net.wooga.test:unity-project-generator-rule:0.3.0'
     testImplementation "com.wooga.spock.extensions:spock-unity-version-manager-extension:0.2.0"


### PR DESCRIPTION
## Description

The `iOSSupport` module is the only package on `macOS` which is archived based on a different base directory than all other packages. This is sadly also true for the linux version of the module. So I adjusted the installation destination when the package destination contains `iOSSupport` in the path.

This patch is done through an update of `net.wooga:unity-version-manager-jni` to version `1.4.1`.

## Changes

* ![FIX]![LINUX] `iOSSupport` module installation destination

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"

