### PR TITLE
Remove coveralls reporting [ATLAS-763]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,23 +12,22 @@ Add short description
 ## Changes
 * ![ADD] add new file x.cs
 * ![FIX] broken `String` in ...
-...
 
 
+[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
+[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
+[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
+[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
+[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
+[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"
 
-
-[NEW]:https://atlas-resources.wooga.com/icons/icon_new.svg "New"
-[ADD]:http://atlas-resources.wooga.com/icons/icon_add.svg "Add"
-[IMPROVE]:http://atlas-resources.wooga.com/icons/icon_improve.svg "Improve"
-[CHANGE]:http://atlas-resources.wooga.com/icons/icon_change.svg "Change"
-[FIX]:http://atlas-resources.wooga.com/icons/icon_fix.svg "Fix"
-[UPDATE]:http://atlas-resources.wooga.com/icons/icon_update.svg "Update"
-
-[BREAK]:http://atlas-resources.wooga.com/icons/icon_break.svg "Break"
-[REMOVE]:http://atlas-resources.wooga.com/icons/icon_remove.svg "Remove"
-[IOS]:http://atlas-resources.wooga.com/icons/icon_iOS.svg "iOS"
-[ANDROID]:http://atlas-resources.wooga.com/icons/icon_android.svg "Android"
-[WEBGL]:http://atlas-resources.wooga.com/icons/icon_webGL.svg "Web:GL"
-[GRADLE]:http://atlas-resources.wooga.com/icons/icon_gradle.svg "Gradle"
-[UNITY]:http://atlas-resources.wooga.com/icons/icon_unity.svg "Unity"
-
+[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
+[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
+[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
+[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
+[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
+[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
+[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
+[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
+[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
+[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,10 +19,10 @@
 
 @Library('github.com/wooga/atlas-jenkins-pipeline@1.x') _
 
-withCredentials([string(credentialsId: 'atlas_unity_version_manager_coveralls_token', variable: 'coveralls_token'),
+withCredentials([
                 string(credentialsId: 'atlas_plugins_sonar_token', variable: 'sonar_token'),
                 string(credentialsId: 'atlas_plugins_snyk_token', variable: 'SNYK_TOKEN')]) {
 
     buildGradlePlugin(platforms:['macos', 'linux'],
-            coverallsToken: coveralls_token, sonarToken: sonar_token, testEnvironment: [])
+            sonarToken: sonar_token, testEnvironment: [])
 }

--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    id 'net.wooga.plugins' version '3.2.0'
+    id 'net.wooga.plugins' version '4.0.0'
     id 'net.wooga.snyk' version '0.10.0'
     id "net.wooga.snyk-gradle-plugin" version "0.2.0"
     id "net.wooga.cve-dependency-resolution" version "0.4.0"


### PR DESCRIPTION
## Description

Because of security issues reported for the coveralls gradle plugin I decided to remove the feature during build. It is not enough to just stop sending reports via jenkins. We also need to update to `net.wooga.plugins` > `4.0.0` because this version removes the dependency.

I remove the coveralls token in the Jenkinsfile so our base pipeline won't try to call the coveralls task on the gradle project.

## Changes

* ![UPDATE] `net.wooga.plugins` to version `4.0.0` to remove coveralls dependency
* ![REMOVE] coveralls token in Jenkinsfile

[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
