### PR TITLE
Add ignorable components property to CheckInstallation

### DIFF
--- a/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
+++ b/src/main/groovy/wooga/gradle/unity/version/manager/UnityVersionManagerPlugin.groovy
@@ -79,6 +79,7 @@ class UnityVersionManagerPlugin implements Plugin<Project> {
             autoSwitchUnityEditor.convention(extension.autoSwitchUnityEditor)
             autoInstallUnityEditor.convention(extension.autoInstallUnityEditor)
             unityInstallBaseDir.convention(extension.unityInstallBaseDir)
+            ignorableUnityComponents.convention([Component.linuxMono, Component.macMono, Component.windowsMono])
         })
 
         project.plugins.withType(UnityPlugin).configureEach({


### PR DESCRIPTION
## Description
Some Unity components are available in some platforms as a part of the system itself, while in other platforms those are available as normal components. For instance, on macOS, the macMono component is a part of unity itself, and its not available as a component. This causes UVM to break on installation if you request the `macMono` component. This situation happens for `macMono`, `linuxMono` and `windowsMono`. 

To fix this, a new Property was introduced to  `UVMCheckInstallation`, where we can list components that if not available to the unity version being installed, will just log a warn message and continue, instead of throwing an error.

## Changes
* ![ADD] `ignorableUnityComponents` to `UVMCheckInstallation`


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
