### PR TITLE
Enforces version 1.8.1 or higher of unity-version-manager-jni

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'net.wooga:unity-version-manager-jni:[1.5.0,2['
+    implementation 'net.wooga:unity-version-manager-jni:[1.8.1,2['
     implementation "net.wooga.gradle:unity:[3,4["
     implementation "com.wooga.gradle:gradle-commons:[1,2["
     implementation 'org.apache.maven:maven-artifact:3.8.1'


### PR DESCRIPTION
## Description
A bug in UVM regarding java version for unity >= 2022.2 was fixed. We need to update this library to propagate the changes to this plugin

## Changes
* ![UPDATE] `net.wooga:unity-version-manager-jni` dependency minimum version to 1.8.1


[NEW]:      https://resources.atlas.wooga.com/icons/icon_new.svg "New"
[ADD]:      https://resources.atlas.wooga.com/icons/icon_add.svg "Add"
[IMPROVE]:  https://resources.atlas.wooga.com/icons/icon_improve.svg "Improve"
[CHANGE]:   https://resources.atlas.wooga.com/icons/icon_change.svg "Change"
[FIX]:      https://resources.atlas.wooga.com/icons/icon_fix.svg "Fix"
[UPDATE]:   https://resources.atlas.wooga.com/icons/icon_update.svg "Update"

[BREAK]:    https://resources.atlas.wooga.com/icons/icon_break.svg "Remove"
[REMOVE]:   https://resources.atlas.wooga.com/icons/icon_remove.svg "Remove"
[IOS]:      https://resources.atlas.wooga.com/icons/icon_iOS.svg "iOS"
[ANDROID]:  https://resources.atlas.wooga.com/icons/icon_android.svg "Android"
[WEBGL]:    https://resources.atlas.wooga.com/icons/icon_webGL.svg "WebGL"
[GRADLE]:   https://resources.atlas.wooga.com/icons/icon_gradle.svg "GRADLE"
[UNITY]:    https://resources.atlas.wooga.com/icons/icon_unity.svg "Unity"
[LINUX]:    https://resources.atlas.wooga.com/icons/icon_linux.svg "Linux"
[WIN]:      https://resources.atlas.wooga.com/icons/icon_windows.svg "Windows"
[MACOS]:    https://resources.atlas.wooga.com/icons/icon_iOS.svg "macOS"
